### PR TITLE
Add Appearance Behavior to PagerChildControllers

### DIFF
--- a/XLPagerTabStrip/XL/Controllers/XLPagerTabStripViewController.m
+++ b/XLPagerTabStrip/XL/Controllers/XLPagerTabStripViewController.m
@@ -283,26 +283,30 @@
     [childViewControllers enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
         UIViewController * childController = (UIViewController *)obj;
         CGFloat pageOffsetForChild = [self pageOffsetForChildIndex:idx];
-        if (fabs(self.containerView.contentOffset.x - pageOffsetForChild) < CGRectGetWidth(self.containerView.bounds)){
-            if (![childController parentViewController]){
+        if (fabs(self.containerView.contentOffset.x - pageOffsetForChild) < CGRectGetWidth(self.containerView.bounds)) {
+            if (![childController parentViewController]) { // Add child
+                [childController beginAppearanceTransition:YES animated:NO];
                 [self addChildViewController:childController];
-                [childController didMoveToParentViewController:self];
+                
                 CGFloat childPosition = [self offsetForChildIndex:idx];
                 [childController.view setFrame:CGRectMake(childPosition, 0, CGRectGetWidth(self.view.bounds), CGRectGetHeight(self.containerView.bounds))];
                 childController.view.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
+                
                 [self.containerView addSubview:childController.view];
-            }
-            else{
+                [childController didMoveToParentViewController:self];
+                [childController endAppearanceTransition];
+            } else {
                 CGFloat childPosition = [self offsetForChildIndex:idx];
                 [childController.view setFrame:CGRectMake(childPosition, 0, CGRectGetWidth(self.view.bounds), CGRectGetHeight(self.containerView.bounds))];
                 childController.view.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
             }
-        }
-        else{
-            if ([childController parentViewController]){
-                [childController.view removeFromSuperview];
+        } else {
+            if ([childController parentViewController]) { // Remove child
                 [childController willMoveToParentViewController:nil];
+                [childController beginAppearanceTransition:NO animated:NO];
+                [childController.view removeFromSuperview];
                 [childController removeFromParentViewController];
+                [childController endAppearanceTransition];
             }
         }
     }];


### PR DESCRIPTION
#### Add Appearance Behavior to PagerChildControllers.

The reason of this PR is to correct the intended behavior of ChildViewControllers of a custom container. According to Apple's document [Creating Custom Container View Controllers] (https://developer.apple.com/library/ios/featuredarticles/ViewControllerPGforiPhoneOS/CreatingCustomContainerViewControllers/CreatingCustomContainerViewControllers.html) 
`To actually inform the child view controller that an appearance transition is occurring, you call the child’s beginAppearanceTransition:animated: and endAppearanceTransition methods.`

The reason was that `viewWillAppear:` wasn't being called for the first child, so
`beginAppearanceTransition: animated:`  to tell the child that its views are about to appear or disappear. And `endAppearanceTransition` to tell the child that the view transition is complete. 

Doing so, corrected the behavior of the ChildViewControllers now viewWillAppear:, viewWillDisappear:, viewDidAppear:, and viewDidDisappear: are being called.
