### PR TITLE
Fixed issue where scrollPercentage would never be equal to 1.0 

### DIFF
--- a/XLPagerTabStrip/XL/Controllers/XLPagerTabStripViewController.m
+++ b/XLPagerTabStrip/XL/Controllers/XLPagerTabStripViewController.m
@@ -266,6 +266,9 @@
 -(CGFloat)scrollPercentage
 {
     if ([self scrollDirection] == XLPagerTabStripDirectionLeft || [self scrollDirection] == XLPagerTabStripDirectionNone){
+        if (fmodf(self.containerView.contentOffset.x, [self pageWidth]) == 0.0) {
+            return 1.0;
+        }
         return fmodf(self.containerView.contentOffset.x, [self pageWidth]) / [self pageWidth];
     }
     return 1 - fmodf(self.containerView.contentOffset.x >= 0 ? self.containerView.contentOffset.x : [self pageWidth] + self.containerView.contentOffset.x, [self pageWidth]) / [self pageWidth];


### PR DESCRIPTION
When `[self scrollDirection] == XLPagerTabStripDirectionLeft` or `[self scrollDirection] == XLPagerTabStripDirectionNone`, the delegate method `pagerTabStripViewController:updateIndicatorFromIndex:toIndex:withProgressPercentage:` never sent back a progressPercentage of 1.0 because the `fmodf` calculation would return inaccurate results. I added a check to explicitly return 1.0 when `self.containerView.contentOffset.x` is an exact multiple of `[self pageWidth]`