### PR TITLE
Bug Fix - Button Bar Selection on Current Page Issues

### DIFF
--- a/XLPagerTabStrip/XL/Controllers/XLButtonBarPagerTabStripViewController.m
+++ b/XLPagerTabStrip/XL/Controllers/XLButtonBarPagerTabStripViewController.m
@@ -168,6 +168,9 @@
 
 - (void)collectionView:(UICollectionView *)collectionView didSelectItemAtIndexPath:(NSIndexPath *)indexPath
 {
+	if (indexPath.item == self.currentIndex)
+		return;
+	
     [self.buttonBarView moveToIndex:indexPath.item animated:YES swipeDirection:XLPagerTabStripDirectionNone];
     self.shouldUpdateButtonBarView = NO;
     


### PR DESCRIPTION
When you select button for current page, selected bar does not update when you scroll container scroll view. The reason is that 'shouldUpdateButtonBarView' varaible does not reset back to true, because [UIScrollViewDelegate scrollViewDidEndScrollingAnimation] is never called when you select button for current page.

I resolved this issue by avoiding current page selection by comparing NSIndexPath.item with self.currentIndex.