### PR TITLE
Bug Fix - PagerTabStrip VC's moveToViewControllerAtIndex:animated:

### DIFF
--- a/XLPagerTabStrip/XL/Controllers/XLPagerTabStripViewController.m
+++ b/XLPagerTabStrip/XL/Controllers/XLPagerTabStripViewController.m
@@ -139,7 +139,7 @@
         self.currentIndex = index;
     }
     else{
-        if (self.skipIntermediateViewControllers && ABS(self.currentIndex - index) > 1){
+        if (animated && self.skipIntermediateViewControllers && ABS(self.currentIndex - index) > 1){
             NSArray * originalPagerTabStripChildViewControllers = self.pagerTabStripChildViewControllers;
             NSMutableArray * tempChildViewControllers = [NSMutableArray arrayWithArray:originalPagerTabStripChildViewControllers];
             UIViewController * currentChildVC = [originalPagerTabStripChildViewControllers objectAtIndex:self.currentIndex];


### PR DESCRIPTION
Animated flag is not respected.

if (self.skipIntermediateViewControllers && ABS(self.currentIndex - index) > 1)) should only be executed when animated is enabled.