### PR TITLE
Fix scroll to next tab when view size was changed.

### DIFF
--- a/XLPagerTabStrip/XL/Controllers/XLPagerTabStripViewController.m
+++ b/XLPagerTabStrip/XL/Controllers/XLPagerTabStripViewController.m
@@ -286,7 +286,6 @@
 {
     if (!CGSizeEqualToSize(_lastSize, self.containerView.bounds.size)){
         _lastSize = self.containerView.bounds.size;
-        [self.containerView setContentOffset:CGPointMake([self pageOffsetForChildIndex:self.currentIndex], 0) animated:NO];
     }
     NSArray * childViewControllers = self.pagerTabStripChildViewControllers;
     self.containerView.contentSize = CGSizeMake(CGRectGetWidth(self.containerView.bounds) * childViewControllers.count, self.containerView.contentSize.height);


### PR DESCRIPTION
When I resize my view, next tap on tab bar will be ignored.

https://www.dropbox.com/s/bbhiv3li5dxwdrl/scroll_issue.mov?dl=0