### PR TITLE
Added (XLSelectedBarAlignment) selectedBarAlignment property to XLButtonBarView

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,11 @@ Customization
 
 The most interesting customizable features are:
 
-* Ability to skip intermediate view controllers when tapped on a "tab".
+* Ability to skip intermediate view controllers when tapped on a "tab" (using `skipIntermediateViewControllers` property)
 * Indicators can be added at any position of the screen through storyboard layouts.
-* Choose between progressive, non-progressive indicators.
-* Add space padding between view controllers.
+* Choose between progressive, non-progressive indicators (using isProgressiveIndicator property)
+* Choose the alignment of the indicator as the user scrolls through tabs (using `barButtonView.selectedBarAlignment` property) 
+* Add space padding between view controllers 
 
 
 
@@ -89,6 +90,10 @@ Requirements
 
 Release Notes
 --------------
+
+Next Version
+
+* `selectedBarAlignment` added to `XLButtonBarView`
 
 Version 2.0.0
 

--- a/XLPagerTabStrip/XL/Controllers/XLButtonBarPagerTabStripViewController.m
+++ b/XLPagerTabStrip/XL/Controllers/XLButtonBarPagerTabStripViewController.m
@@ -80,7 +80,6 @@
 -(void)viewWillAppear:(BOOL)animated
 {
     [super viewWillAppear:animated];
-    [self.buttonBarView layoutIfNeeded];
     [self.buttonBarView moveToIndex:self.currentIndex animated:NO swipeDirection:XLPagerTabStripDirectionNone pagerScroll:(self.isProgressiveIndicator ? XLPagerScrollYES  :XLPagerScrollOnlyIfOutOfScreen)];
 }
 

--- a/XLPagerTabStrip/XL/Views/XLButtonBarView.h
+++ b/XLPagerTabStrip/XL/Views/XLButtonBarView.h
@@ -33,10 +33,18 @@ typedef NS_ENUM(NSUInteger, XLPagerScroll) {
     XLPagerScrollOnlyIfOutOfScreen
 };
 
+typedef NS_ENUM(NSUInteger, XLSelectedBarAlignment) {
+    XLSelectedBarAlignmentLeft,
+    XLSelectedBarAlignmentCenter,
+    XLSelectedBarAlignmentRight,
+    XLSelectedBarAlignmentProgressive
+};
+
 @interface XLButtonBarView : UICollectionView
 
 @property (readonly, nonatomic) UIView * selectedBar;
 @property (nonatomic) CGFloat selectedBarHeight;
+@property (nonatomic) XLSelectedBarAlignment selectedBarAlignment;
 @property UIFont * labelFont;
 @property NSUInteger leftRightMargin;
 


### PR DESCRIPTION
... so that developers can choose how the selectedBar gets aligns as the user scrolls through view controllers.

Additionally consolidated some duplicated code into a new method contentOffsetForCellWithFrame:index: so there is a single place where the contentOffset (i.e. the selectedBar alignment) is calculated (regardless of whether the user tapped a tab/cell or scrolled the UIPageViewController).