### PR TITLE
Added BOOL shouldCellsFillAvailableWidth property to XLButtonBarPagerTabStripViewController…

### DIFF
--- a/XLPagerTabStrip/XL/Controllers/XLButtonBarPagerTabStripViewController.h
+++ b/XLPagerTabStrip/XL/Controllers/XLButtonBarPagerTabStripViewController.h
@@ -33,5 +33,6 @@
 @property (copy) void (^changeCurrentIndexBlock)(XLButtonBarViewCell* oldCell, XLButtonBarViewCell *newCell, BOOL animated);
 
 @property (readonly, nonatomic) XLButtonBarView * buttonBarView;
+@property (assign, nonatomic) BOOL shouldCellsFillAvailableWidth;
 
 @end

--- a/XLPagerTabStrip/XL/Controllers/XLButtonBarPagerTabStripViewController.m
+++ b/XLPagerTabStrip/XL/Controllers/XLButtonBarPagerTabStripViewController.m
@@ -30,13 +30,15 @@
 
 @property (nonatomic) IBOutlet XLButtonBarView * buttonBarView;
 @property (nonatomic) BOOL shouldUpdateButtonBarView;
+@property (nonatomic) NSArray *cachedCellWidths;
+@property (nonatomic) BOOL isViewAppearing;
+@property (nonatomic) BOOL isViewRotating;
 
 @end
 
 @implementation XLButtonBarPagerTabStripViewController
-{
-    XLButtonBarViewCell * _sizeCell;
-}
+
+#pragma mark - Initialisation
 
 - (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil
 {
@@ -56,6 +58,9 @@
     return self;
 }
 
+
+#pragma mark - View Lifecycle
+
 - (void)viewDidLoad
 {
     [super viewDidLoad];
@@ -71,21 +76,85 @@
     }
     self.buttonBarView.labelFont = [UIFont boldSystemFontOfSize:18.0f];
     self.buttonBarView.leftRightMargin = 8;
-    [self.buttonBarView setScrollsToTop:NO];
-    UICollectionViewFlowLayout * flowLayout = (id)self.buttonBarView.collectionViewLayout;
-    [flowLayout setScrollDirection:UICollectionViewScrollDirectionHorizontal];
-    [self.buttonBarView setShowsHorizontalScrollIndicator:NO];
+    self.buttonBarView.scrollsToTop = NO;
+    UICollectionViewFlowLayout *flowLayout = (id)self.buttonBarView.collectionViewLayout;
+    flowLayout.scrollDirection = UICollectionViewScrollDirectionHorizontal;
+    self.buttonBarView.showsHorizontalScrollIndicator = NO;
 }
 
 -(void)viewWillAppear:(BOOL)animated
 {
     [super viewWillAppear:animated];
     [self.buttonBarView layoutIfNeeded];
-    [self.buttonBarView moveToIndex:self.currentIndex animated:NO swipeDirection:XLPagerTabStripDirectionNone pagerScroll:(self.isProgressiveIndicator ? XLPagerScrollYES  :XLPagerScrollOnlyIfOutOfScreen)];
+    self.isViewAppearing = YES;
 }
+
+-(void)viewDidAppear:(BOOL)animated
+{
+    [super viewWillAppear:animated];
+    self.isViewAppearing = NO;
+}
+
+- (void)viewWillLayoutSubviews
+{
+    [super viewWillLayoutSubviews];
+    
+    if (self.isViewAppearing || self.isViewRotating)
+    {
+        // Force the UICollectionViewFlowLayout to get laid out again with the new size if
+        // a) The view is appearing.  This ensures that
+        //    collectionView:layout:sizeForItemAtIndexPath: is called for a second time
+        //    when the view is shown and when the view *frame(s)* are actually set
+        //    (we need the view frame's to have been set to work out the size's and on the
+        //    first call to collectionView:layout:sizeForItemAtIndexPath: the view frame(s)
+        //    aren't set correctly)
+        // b) The view is rotating.  This ensures that
+        //    collectionView:layout:sizeForItemAtIndexPath: is called again and can use the views
+        //    *new* frame so that the buttonBarView cell's actually get resized correctly
+        self.cachedCellWidths = nil; // Clear/invalidate our cache of cell widths
+        UICollectionViewFlowLayout *flowLayout = (id)self.buttonBarView.collectionViewLayout;
+        [flowLayout invalidateLayout];
+        
+        // Ensure the buttonBarView.frame is sized correctly after rotation on iOS 7 devices
+        [self.buttonBarView layoutIfNeeded];
+        
+        // When the view first appears or is rotated we also need to ensure that the barButtonView's
+        // selectedBar is resized and its contentOffset/scroll is set correctly (the selected
+        // tab/cell may end up either skewed or off screen after a rotation otherwise)
+        [self.buttonBarView moveToIndex:self.currentIndex animated:NO swipeDirection:XLPagerTabStripDirectionNone pagerScroll:XLPagerScrollOnlyIfOutOfScreen];
+    }
+}
+
+
+#pragma mark - View Rotation
+
+// Called on iOS 8+ only
+- (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator
+{
+    [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
+    self.isViewRotating = YES;
+}
+
+// Called on iOS 7 only
+-(void)willRotateToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration
+{
+    [super willRotateToInterfaceOrientation:toInterfaceOrientation duration:duration];
+    self.isViewRotating = YES;
+}
+
+-(void)didRotateFromInterfaceOrientation:(UIInterfaceOrientation)fromInterfaceOrientation
+{
+    [super didRotateFromInterfaceOrientation:fromInterfaceOrientation];
+    self.isViewRotating = NO;
+}
+
+
+#pragma mark - Public methods
 
 -(void)reloadPagerTabStripView
 {
+    self.cachedCellWidths = nil; // Clear/invalidate our cache of cell widths
+    
     [super reloadPagerTabStripView];
     if ([self isViewLoaded]){
         [self.buttonBarView reloadData];
@@ -100,14 +169,123 @@
 {
     if (_buttonBarView) return _buttonBarView;
     UICollectionViewFlowLayout * flowLayout = [[UICollectionViewFlowLayout alloc] init];
-    [flowLayout setScrollDirection:UICollectionViewScrollDirectionHorizontal];
-    [flowLayout setSectionInset:UIEdgeInsetsMake(0, 35, 0, 35)];
+    flowLayout.scrollDirection = UICollectionViewScrollDirectionHorizontal;
+    flowLayout.sectionInset = UIEdgeInsetsMake(0, 35, 0, 35);
     _buttonBarView = [[XLButtonBarView alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, 44.0f) collectionViewLayout:flowLayout];
     _buttonBarView.backgroundColor = [UIColor orangeColor];
     _buttonBarView.selectedBar.backgroundColor = [UIColor blackColor];
     _buttonBarView.autoresizingMask = UIViewAutoresizingFlexibleWidth;
     return _buttonBarView;
 }
+
+- (NSArray *)cachedCellWidths
+{
+    if (!_cachedCellWidths)
+    {
+        // First calculate the minimum width required by each cell
+        
+        UICollectionViewFlowLayout *flowLayout = (id)self.buttonBarView.collectionViewLayout;
+        NSUInteger numberOfCells = self.pagerTabStripChildViewControllers.count;
+        
+        NSMutableArray *minimumCellWidths = [[NSMutableArray alloc] init];
+        
+        CGFloat collectionViewContentWidth = 0;
+        
+        for (UIViewController<XLPagerTabStripChildItem> *childController in self.pagerTabStripChildViewControllers)
+        {
+            UILabel *label = [[UILabel alloc] init];
+            label.translatesAutoresizingMaskIntoConstraints = NO;
+            label.font = self.buttonBarView.labelFont;
+            label.text = [childController titleForPagerTabStripViewController:self];
+            CGSize labelSize = [label intrinsicContentSize];
+            
+            CGFloat minimumCellWidth = labelSize.width + (self.buttonBarView.leftRightMargin * 2);
+            NSNumber *minimumCellWidthValue = [NSNumber numberWithFloat:minimumCellWidth];
+            [minimumCellWidths addObject:minimumCellWidthValue];
+            
+            collectionViewContentWidth += minimumCellWidth;
+        }
+        
+        // To get an acurate collectionViewContentWidth account for the spacing between cells
+        CGFloat cellSpacingTotal = ((numberOfCells-1) * flowLayout.minimumInteritemSpacing);
+        collectionViewContentWidth += cellSpacingTotal;
+        
+        CGFloat collectionViewAvailableVisibleWidth = self.buttonBarView.frame.size.width - flowLayout.sectionInset.left - flowLayout.sectionInset.right;
+        
+        // Do we need to stetch any of the cell widths to fill the screen width?
+        if (!self.shouldCellsFillAvailableWidth || collectionViewAvailableVisibleWidth < collectionViewContentWidth)
+        {
+            // The collection view's content width is larger that the visible width available so it needs to scroll
+            // OR shouldCellsFillAvailableWidth == NO...
+            // No need to stretch any of the cells, we can just use the minimumCellWidths for the cell widths.
+            _cachedCellWidths = minimumCellWidths;
+        }
+        else
+        {
+            // The collection view's content width is smaller that the visible width available so it won't ever scroll
+            // AND shouldCellsFillAvailableWidth == YES so we want to stretch the cells to fill the width.
+            // We now need to calculate how much to stretch each tab...
+            
+            // In an ideal world the cell's would all have an equal width, however the cell labels vary in length
+            // so some of the longer labelled cells might not need to stetch where as the shorter labelled cells do.
+            // In order to determine what needs to stretch and what doesn't we have to recurse through suggestedStetchedCellWidth
+            // values (the value decreases with each recursive call) until we find a value that works.
+            // The first value to try is the largest (for the case where all the cell widths are equal)
+            CGFloat stetchedCellWidthIfAllEqual = (collectionViewAvailableVisibleWidth - cellSpacingTotal) / numberOfCells;
+            
+            CGFloat generalMiniumCellWidth = [self calculateStretchedCellWidths:minimumCellWidths suggestedStetchedCellWidth:stetchedCellWidthIfAllEqual previousNumberOfLargeCells:0];
+            
+            NSMutableArray *stetchedCellWidths = [[NSMutableArray alloc] init];
+            
+            for (NSNumber *minimumCellWidthValue in minimumCellWidths)
+            {
+                CGFloat minimumCellWidth = minimumCellWidthValue.floatValue;
+                CGFloat cellWidth = (minimumCellWidth > generalMiniumCellWidth) ? minimumCellWidth : generalMiniumCellWidth;
+                NSNumber *cellWidthValue = [NSNumber numberWithFloat:cellWidth];
+                [stetchedCellWidths addObject:cellWidthValue];
+            }
+            
+            _cachedCellWidths = stetchedCellWidths;
+        }
+    }
+    return _cachedCellWidths;
+}
+
+- (CGFloat)calculateStretchedCellWidths:(NSArray *)minimumCellWidths suggestedStetchedCellWidth:(CGFloat)suggestedStetchedCellWidth previousNumberOfLargeCells:(NSUInteger)previousNumberOfLargeCells
+{
+    // Recursively attempt to calculate the stetched cell width
+    
+    NSUInteger numberOfLargeCells = 0;
+    CGFloat totalWidthOfLargeCells = 0;
+    
+    for (NSNumber *minimumCellWidthValue in minimumCellWidths)
+    {
+        CGFloat minimumCellWidth = minimumCellWidthValue.floatValue;
+        if (minimumCellWidth > suggestedStetchedCellWidth) {
+            totalWidthOfLargeCells += minimumCellWidth;
+            numberOfLargeCells++;
+        }
+    }
+    
+    // Is the suggested width any good?
+    if (numberOfLargeCells > previousNumberOfLargeCells)
+    {
+        // The suggestedStetchedCellWidth is no good :-( ... calculate a new suggested width
+        UICollectionViewFlowLayout *flowLayout = (id)self.buttonBarView.collectionViewLayout;
+        CGFloat collectionViewAvailableVisibleWidth = self.buttonBarView.frame.size.width - flowLayout.sectionInset.left - flowLayout.sectionInset.right;
+        NSUInteger numberOfCells = minimumCellWidths.count;
+        CGFloat cellSpacingTotal = ((numberOfCells-1) * flowLayout.minimumInteritemSpacing);
+        
+        NSUInteger numberOfSmallCells = numberOfCells - numberOfLargeCells;
+        CGFloat newSuggestedStetchedCellWidth =  (collectionViewAvailableVisibleWidth - totalWidthOfLargeCells - cellSpacingTotal) / numberOfSmallCells;
+        
+        return [self calculateStretchedCellWidths:minimumCellWidths suggestedStetchedCellWidth:newSuggestedStetchedCellWidth previousNumberOfLargeCells:numberOfLargeCells];
+    }
+    
+    // The suggestion is good
+    return suggestedStetchedCellWidth;
+}
+
 
 #pragma mark - XLPagerTabStripViewControllerDelegate
 
@@ -148,18 +326,17 @@
     }
 }
 
-#pragma merk - UICollectionViewDelegateFlowLayout
+#pragma mark - UICollectionViewDelegateFlowLayout
 
 - (CGSize)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout*)collectionViewLayout sizeForItemAtIndexPath:(NSIndexPath *)indexPath
 {
-    UILabel * label = [[UILabel alloc] init];
-    [label setTranslatesAutoresizingMaskIntoConstraints:NO];
-    label.font = self.buttonBarView.labelFont;
-    UIViewController<XLPagerTabStripChildItem> * childController =   [self.pagerTabStripChildViewControllers objectAtIndex:indexPath.item];
-    [label setText:[childController titleForPagerTabStripViewController:self]];
-    CGSize labelSize = [label intrinsicContentSize];
-    
-    return CGSizeMake(labelSize.width + (self.buttonBarView.leftRightMargin * 2), collectionView.frame.size.height);
+    if (self.cachedCellWidths.count > indexPath.row)
+    {
+        NSNumber *cellWidthValue = self.cachedCellWidths[indexPath.row];
+        CGFloat cellWidth = [cellWidthValue floatValue];
+        return CGSizeMake(cellWidth, collectionView.frame.size.height);
+    }
+    return CGSizeZero;
 }
 
 #pragma mark - UICollectionViewDelegate

--- a/XLPagerTabStrip/XL/Controllers/XLButtonBarPagerTabStripViewController.m
+++ b/XLPagerTabStrip/XL/Controllers/XLButtonBarPagerTabStripViewController.m
@@ -91,7 +91,7 @@
 
 -(void)viewDidAppear:(BOOL)animated
 {
-    [super viewWillAppear:animated];
+    [super viewDidAppear:animated];
     self.isViewAppearing = NO;
 }
 


### PR DESCRIPTION
… so that developers can choose whether the cells should stretch to fill the screen width when there are a small number of tabs/cells.  Was also necessary to fix some existing problems with rotation.