### PR TITLE
Bug Fix - PagerTabStrip VC's updateContent

### DIFF
--- a/XLPagerTabStrip/XL/Controllers/XLPagerTabStripViewController.m
+++ b/XLPagerTabStrip/XL/Controllers/XLPagerTabStripViewController.m
@@ -301,8 +301,8 @@
         CGFloat pageOffsetForChild = [self pageOffsetForChildIndex:idx];
         if (fabs(self.containerView.contentOffset.x - pageOffsetForChild) < CGRectGetWidth(self.containerView.bounds)) {
             if (![childController parentViewController]) { // Add child
-                [childController beginAppearanceTransition:YES animated:NO];
                 [self addChildViewController:childController];
+                [childController beginAppearanceTransition:YES animated:NO];
                 
                 CGFloat childPosition = [self offsetForChildIndex:idx];
                 [childController.view setFrame:CGRectMake(childPosition, 0, CGRectGetWidth(self.view.bounds), CGRectGetHeight(self.containerView.bounds))];


### PR DESCRIPTION
beginAppearanceTransition:animated: are called before addChildViewController:.
This cause a crash when a childViewController refers the parentViewController's objects such as navigationController in viewWillAppear:.
So, beginAppearanceTransition:animated: should be called after addChildViewController:.