### PR TITLE
Fixed KVC remove observer crash for XLTwitterPagerTabStripViewController

### DIFF
--- a/XLPagerTabStrip/XL/Controllers/XLTwitterPagerTabStripViewController.m
+++ b/XLPagerTabStrip/XL/Controllers/XLTwitterPagerTabStripViewController.m
@@ -174,7 +174,11 @@
 
 -(void)dealloc
 {
-    [self.navigationView removeObserver:self forKeyPath:@"frame"];
+    // Perform a try catch when removing a observer in case it was never registered
+    @try {
+        [self.navigationView removeObserver:self forKeyPath:@"frame"];
+    }
+    @catch (NSException * __unused exception) {}
 }
 
 


### PR DESCRIPTION
Fixed the following issue #86 https://github.com/xmartlabs/XLPagerTabStrip/issues/86 
There is a issue caused by the fact that we remove an observer before registering it.

Error : 
*** Terminating app due to uncaught exception 'NSRangeException', reason: 'Cannot remove an observer for the key path "frame" from because it is not registered as an observer.'

Added a try catch for the remove observer call in XLTwitterPagerTabStripViewController