### PR TITLE
Made ButtonBarPagerTabStripViewController initializer public

### DIFF
--- a/Sources/ButtonBarPagerTabStripViewController.swift
+++ b/Sources/ButtonBarPagerTabStripViewController.swift
@@ -98,7 +98,7 @@ public class ButtonBarPagerTabStripViewController: PagerTabStripViewController, 
         return self.calculateWidths()
     }()
     
-    override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: NSBundle?) {
+    override public init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: NSBundle?) {
         super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
         delegate = self
         datasource = self


### PR DESCRIPTION
This helps to subclass ButtonBarPagerTabStripViewController. In my case I wasn't able to use default initializer without parameters because `init(nibName: String?, bundle: String?)` is internal.