### PR TITLE
Moved the logic to enable the user interaction of the views outside t…

### DIFF
--- a/XLPagerTabStrip/XL/Controllers/XLPagerTabStripViewController.m
+++ b/XLPagerTabStrip/XL/Controllers/XLPagerTabStripViewController.m
@@ -441,17 +441,17 @@
 {
     if (self.containerView == scrollView && _pagerTabStripChildViewControllersForScrolling){
         _pagerTabStripChildViewControllersForScrolling = nil;
-        if (self.navigationController){
-            self.navigationController.view.userInteractionEnabled = YES;
-        }
-        else{
-            self.view.userInteractionEnabled = YES;
-        }
+        
         [self updateContent];
     }
+    
+    if (self.navigationController){
+        self.navigationController.view.userInteractionEnabled = YES;
+    }
+    else{
+        self.view.userInteractionEnabled = YES;
+    }
 }
-
-
 
 #pragma mark - Orientation
 


### PR DESCRIPTION
Moved the logic to enable the user interaction of the views outside the condition in the method scrollViewDidEndScrollingAnimation:

This way we make sure the interface never gets disabled forever if the user interacts with the interface like crazy tapping every button fast.


Addresses Issue #124 : App becomes unresponsive after randomly tapping the tabs quickly #124