### PR TITLE
Remove wrong observer when deinit

### DIFF
--- a/Sources/TwitterPagerTabStripViewController.swift
+++ b/Sources/TwitterPagerTabStripViewController.swift
@@ -123,7 +123,7 @@ public class TwitterPagerTabStripViewController: PagerTabStripViewController, Pa
     }
     
     deinit {
-        NSNotificationCenter.defaultCenter().removeObserver(self)
+        titleView.removeObserver(self, forKeyPath: "frame")
     }
     
     public override func viewDidLayoutSubviews() {


### PR DESCRIPTION
Remove a wrong observer in TwitterPagerTabStripViewController.swift.
How to reproduce in Example project:

1. Select **PageTabController Types**
2. Select the **Twitter** tab
3. Select the **Bar** tab
4. Select **Close** to dismiss the view controller.

Then the app will crash with error **An instance of class … is being deallocated while key value observing are still registered with it**