### PR TITLE
Call delegate even if it's a progressive tab strip

### DIFF
--- a/Sources/PagerTabStripViewController.swift
+++ b/Sources/PagerTabStripViewController.swift
@@ -250,7 +250,8 @@ public class PagerTabStripViewController: UIViewController, UIScrollViewDelegate
             let (fromIndex, toIndex, scrollPercentage) = progressiveIndicatorData(virtualPage)
             progressiveDeledate.pagerTabStripViewController(self, updateIndicatorFromIndex: fromIndex, toIndex: toIndex, withProgressPercentage: scrollPercentage, indexWasChanged: changeCurrentIndex)
         }
-        else{
+        
+        if changeCurrentIndex {
             delegate?.pagerTabStripViewController(self, updateIndicatorFromIndex: min(oldCurrentIndex, pagerViewControllers.count - 1), toIndex: newCurrentIndex)
         }
     }


### PR DESCRIPTION
Not sure if everyone, but I use the delegate method to track the tab switching. I need it to be called even when using the progressive tab strip behaviour
