### PR TITLE
Updated the deployment target to iOS 7.0

### DIFF
--- a/XLPagerTabStrip.podspec
+++ b/XLPagerTabStrip.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.source   = { :git => 'https://github.com/xmartlabs/XLPagerTabStrip.git', :tag => s.version }
   s.source_files = 'XLPagerTabStrip/XL/**/*.{h,m}'
   s.requires_arc = true
-  s.ios.deployment_target = '8.0'
+  s.ios.deployment_target = '7.0'
   s.ios.frameworks = 'UIKit', 'Foundation'
   s.resource_bundles = { 'XLPagerTabStrip' => ['XLPagerTabStrip/XL/Views/ButtonCell.xib'] }
 end


### PR DESCRIPTION
This update is useful to use the version 3.0 of XLPagerTabStrip in the projects using 7.0 as cocoapods  deployment target and to skip this error when update this pod:
Specs satisfying the `XLPagerTabStrip (~> 3.0)` dependency were found, but they required a higher minimum deployment target.

If you accept this pull request please release a minor update for XLPagerTabStrip in obj-c
