### PR TITLE
New feature added: isSelectedBarBelow for ButtonBar style

### DIFF
--- a/Example.xcodeproj/project.pbxproj
+++ b/Example.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1C696B561CBB3F4D009D269C /* ButtonBarExampleSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C696B551CBB3F4D009D269C /* ButtonBarExampleSettingsViewController.swift */; };
 		285718181C568336004D7E7B /* DataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 285718171C568336004D7E7B /* DataProvider.swift */; };
 		285DA2881C569AA2000908CA /* ChildExampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 285DA2861C569AA2000908CA /* ChildExampleViewController.swift */; };
 		285DA2891C569AA2000908CA /* TableChildExampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 285DA2871C569AA2000908CA /* TableChildExampleViewController.swift */; };
@@ -78,6 +79,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		1C696B551CBB3F4D009D269C /* ButtonBarExampleSettingsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ButtonBarExampleSettingsViewController.swift; path = Example/ButtonBarExampleSettingsViewController.swift; sourceTree = "<group>"; };
 		285718171C568336004D7E7B /* DataProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DataProvider.swift; path = Example/Helpers/DataProvider.swift; sourceTree = "<group>"; };
 		285DA2861C569AA2000908CA /* ChildExampleViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ChildExampleViewController.swift; path = Example/ChildControllers/ChildExampleViewController.swift; sourceTree = "<group>"; };
 		285DA2871C569AA2000908CA /* TableChildExampleViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TableChildExampleViewController.swift; path = Example/ChildControllers/TableChildExampleViewController.swift; sourceTree = "<group>"; };
@@ -230,6 +232,7 @@
 				CB86ED6F1C4D6F0D00DA463B /* Assets.xcassets */,
 				CB71C6EA1C4EB964008EC806 /* SegmentedExampleViewController.swift */,
 				CB3697BE1C5177B4001FC5F8 /* ButtonBarExampleViewController.swift */,
+				1C696B551CBB3F4D009D269C /* ButtonBarExampleSettingsViewController.swift */,
 				CBA0A1FE1C50304500C5748C /* BarExampleViewController.swift */,
 				CBA0A2031C5033B400C5748C /* ReloadExampleViewController.swift */,
 				CBBD435E1C5274AE001A748E /* NavButtonBarExampleViewController.swift */,
@@ -379,6 +382,7 @@
 				CB71C6EB1C4EB964008EC806 /* SegmentedExampleViewController.swift in Sources */,
 				28F828D01C4B714D00330CF4 /* AppDelegate.swift in Sources */,
 				CBA0A2041C5033B400C5748C /* ReloadExampleViewController.swift in Sources */,
+				1C696B561CBB3F4D009D269C /* ButtonBarExampleSettingsViewController.swift in Sources */,
 				285DA2901C59C587000908CA /* SpotifyExampleViewController.swift in Sources */,
 				CB3697BF1C5177B4001FC5F8 /* ButtonBarExampleViewController.swift in Sources */,
 				285DA2881C569AA2000908CA /* ChildExampleViewController.swift in Sources */,

--- a/Example/Example/Base.lproj/Storyboard.storyboard
+++ b/Example/Example/Base.lproj/Storyboard.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9531" systemVersion="15D21" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="SCa-L8-uTr">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="SCa-L8-uTr">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="Navigation items with more than one left or right bar item" minToolsVersion="7.0"/>
     </dependencies>
@@ -173,6 +173,12 @@
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="Buttons Example" id="anf-yu-jjb">
+                        <barButtonItem key="leftBarButtonItem" title="Settings" id="CBZ-Fi-aje">
+                            <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                            <connections>
+                                <action selector="editTapped:" destination="3jo-Zp-rsN" id="5qF-HG-uZw"/>
+                            </connections>
+                        </barButtonItem>
                         <barButtonItem key="rightBarButtonItem" systemItem="refresh" id="frU-Vs-ZeP">
                             <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                             <connections>
@@ -245,11 +251,11 @@
                                         <rect key="frame" x="0.0" y="35" width="600" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="oTF-WE-AbG" id="6M8-2g-4Tv">
-                                            <rect key="frame" x="0.0" y="0.0" width="600" height="43"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="600" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="PageTabController Types" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Wj6-fs-BjA">
-                                                    <rect key="frame" x="15" y="0.0" width="570" height="43"/>
+                                                    <rect key="frame" x="15" y="0.0" width="570" height="43.5"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -269,11 +275,11 @@
                                         <rect key="frame" x="0.0" y="115" width="600" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Lqx-q4-U6Y" id="6Oi-8U-mzD">
-                                            <rect key="frame" x="0.0" y="0.0" width="600" height="43"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="600" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Instagram Example" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="GIb-gr-QYX">
-                                                    <rect key="frame" x="15" y="0.0" width="570" height="43"/>
+                                                    <rect key="frame" x="15" y="0.0" width="570" height="43.5"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -289,11 +295,11 @@
                                         <rect key="frame" x="0.0" y="159" width="600" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="5tn-pD-005" id="U8A-o0-QLd">
-                                            <rect key="frame" x="0.0" y="0.0" width="600" height="43"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="600" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Youtube Example" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="68O-MH-NQl">
-                                                    <rect key="frame" x="15" y="0.0" width="570" height="43"/>
+                                                    <rect key="frame" x="15" y="0.0" width="570" height="43.5"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -309,11 +315,11 @@
                                         <rect key="frame" x="0.0" y="203" width="600" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="WB2-oq-b4x" id="2mV-U6-6pj">
-                                            <rect key="frame" x="0.0" y="0.0" width="600" height="43"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="600" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Spotify Example" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="bPv-uB-GeS">
-                                                    <rect key="frame" x="15" y="0.0" width="570" height="43"/>
+                                                    <rect key="frame" x="15" y="0.0" width="570" height="43.5"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -525,6 +531,86 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="ls9-Xb-7by" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="3018" y="514.5"/>
+        </scene>
+        <!--Settings-->
+        <scene sceneID="5dZ-D8-HPM">
+            <objects>
+                <tableViewController storyboardIdentifier="ButtonBarExampleSettings" title="Settings" id="Cv4-u1-7PX" customClass="ButtonBarExampleSettingsViewController" customModule="Example" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="NjP-h8-m4E">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <sections>
+                            <tableViewSection id="PVA-pU-gWc">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="mG4-CX-YIC">
+                                        <rect key="frame" x="0.0" y="64" width="600" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="mG4-CX-YIC" id="m81-8M-IBd">
+                                            <rect key="frame" x="0.0" y="0.0" width="600" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="isSelectedBarBelow" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iY4-VA-RwP">
+                                                    <rect key="frame" x="16" y="11" width="152" height="21"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="5tu-R0-uW5">
+                                                    <rect key="frame" x="535" y="6" width="51" height="31"/>
+                                                    <connections>
+                                                        <action selector="switchIsSelectedBarBelowValueChanged:" destination="Cv4-u1-7PX" eventType="valueChanged" id="Bcl-xn-rZl"/>
+                                                    </connections>
+                                                </switch>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="iY4-VA-RwP" firstAttribute="centerY" secondItem="m81-8M-IBd" secondAttribute="centerY" id="9uJ-Ui-ArP"/>
+                                                <constraint firstItem="5tu-R0-uW5" firstAttribute="centerY" secondItem="m81-8M-IBd" secondAttribute="centerY" id="f1q-Qb-uqX"/>
+                                                <constraint firstAttribute="trailingMargin" secondItem="5tu-R0-uW5" secondAttribute="trailing" constant="8" id="oUe-4H-2BH"/>
+                                                <constraint firstItem="iY4-VA-RwP" firstAttribute="leading" secondItem="m81-8M-IBd" secondAttribute="leadingMargin" constant="8" id="q0Z-Xu-Foe"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="cTd-eM-SnX">
+                                        <rect key="frame" x="0.0" y="108" width="600" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="cTd-eM-SnX" id="aAH-xS-AHX">
+                                            <rect key="frame" x="0.0" y="0.0" width="600" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ATQ-9b-FJk">
+                                                    <rect key="frame" x="275" y="7" width="51" height="30"/>
+                                                    <state key="normal" title="Update"/>
+                                                    <connections>
+                                                        <action selector="btnUpdateTap:" destination="Cv4-u1-7PX" eventType="touchUpInside" id="OHN-tj-uiQ"/>
+                                                    </connections>
+                                                </button>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="ATQ-9b-FJk" firstAttribute="centerX" secondItem="aAH-xS-AHX" secondAttribute="centerX" id="VrA-v0-RZ0"/>
+                                                <constraint firstItem="ATQ-9b-FJk" firstAttribute="centerY" secondItem="aAH-xS-AHX" secondAttribute="centerY" id="gmy-wC-pIs"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                        </sections>
+                        <connections>
+                            <outlet property="dataSource" destination="Cv4-u1-7PX" id="zDH-R7-RL6"/>
+                            <outlet property="delegate" destination="Cv4-u1-7PX" id="Qrx-U0-LqM"/>
+                        </connections>
+                    </tableView>
+                    <toolbarItems/>
+                    <simulatedStatusBarMetrics key="simulatedStatusBarMetrics"/>
+                    <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
+                    <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
+                    <connections>
+                        <outlet property="switchView" destination="5tu-R0-uW5" id="pvl-UH-RKw"/>
+                    </connections>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="HoU-Cj-lqZ" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2201" y="1202"/>
         </scene>
         <!--Twitter Example View Controller-->
         <scene sceneID="Zfp-Dk-WxL">

--- a/Example/Example/ButtonBarExampleSettingsViewController.swift
+++ b/Example/Example/ButtonBarExampleSettingsViewController.swift
@@ -1,0 +1,36 @@
+//
+//  ButtonBarExampleSettingsViewController.swift
+//  Example
+//
+//  Created by Luciano Sugiura on 10/04/16.
+//
+//
+
+import UIKit
+import XLPagerTabStrip
+
+protocol ButtonBarExampleSettingsDelegate: class {
+    func buttonBarExampleSettings(isSelectedBarBelow isSelectedBarBelow: Bool)
+    func buttonBarExampleSettingsUpdateTapped()
+    func buttonBarExampleSettingsIsSelectedBarBelow() -> Bool
+}
+
+class ButtonBarExampleSettingsViewController: UITableViewController {
+    
+    @IBOutlet weak var switchView: UISwitch!
+    
+    weak var delegate: ButtonBarExampleSettingsDelegate?
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        switchView.on = delegate?.buttonBarExampleSettingsIsSelectedBarBelow() ?? false
+    }
+    
+    @IBAction func switchIsSelectedBarBelowValueChanged(sender: UISwitch) {
+        delegate?.buttonBarExampleSettings(isSelectedBarBelow: sender.on)
+    }
+    
+    @IBAction func btnUpdateTap(sender: UIButton) {
+        delegate?.buttonBarExampleSettingsUpdateTapped()
+    }
+}

--- a/Example/Example/ButtonBarExampleViewController.swift
+++ b/Example/Example/ButtonBarExampleViewController.swift
@@ -31,7 +31,6 @@ class ButtonBarExampleViewController: ButtonBarPagerTabStripViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
         buttonBarView.selectedBar.backgroundColor = .orangeColor()
         buttonBarView.backgroundColor = UIColor(red: 7/255, green: 185/255, blue: 155/255, alpha: 1)
     }
@@ -74,5 +73,26 @@ class ButtonBarExampleViewController: ButtonBarPagerTabStripViewController {
             pagerBehaviour = .Common(skipIntermediateViewControllers: rand() % 2 == 0)
         }
         super.reloadPagerTabStripView()
+    }
+    
+    override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {
+        if segue.identifier == "ButtonBarExampleSettings" {
+            let controller = segue.destinationViewController as! ButtonBarExampleSettingsViewController
+            controller.delegate = self
+        }
+    }
+}
+
+extension ButtonBarExampleViewController: ButtonBarExampleSettingsDelegate {
+    func buttonBarExampleSettings(isSelectedBarBelow isSelectedBarBelow: Bool) {
+        buttonBarView.isSelectedBarBelow = isSelectedBarBelow
+    }
+    func buttonBarExampleSettingsUpdateTapped() {
+        navigationController?.dismissViewControllerAnimated(true) {
+            super.reloadPagerTabStripView()
+        }
+    }
+    func buttonBarExampleSettingsIsSelectedBarBelow() -> Bool {
+        return buttonBarView.isSelectedBarBelow
     }
 }

--- a/Example/Example/ReloadExampleViewController.swift
+++ b/Example/Example/ReloadExampleViewController.swift
@@ -70,6 +70,20 @@ class ReloadExampleViewController: UIViewController {
         dismissViewControllerAnimated(true, completion: nil)
     }
     
+    @IBAction func editTapped(sender: UIBarButtonItem) {
+        let settings = storyboard?.instantiateViewControllerWithIdentifier("ButtonBarExampleSettings")
+            as! ButtonBarExampleSettingsViewController
+        
+        let _ = childViewControllers.flatMap { element in
+            return element as? ButtonBarExampleViewController
+        }.map { controller in
+            settings.delegate = controller
+        }
+        
+        let nav = UINavigationController(rootViewController: settings)
+        presentViewController(nav, animated: true, completion: nil)
+    }
+    
     func updateTitle(pagerTabStripViewController: PagerTabStripViewController) {
         func stringFromBool(bool: Bool) -> String {
             return bool ? "YES" : "NO"

--- a/README.md
+++ b/README.md
@@ -204,6 +204,9 @@ settings.style.buttonBarRightContentInset: CGFloat?
 settings.style.selectedBarBackgroundColor = UIColor.blackColor()
 settings.style.selectedBarHeight: CGFloat = 5
 
+// if you want the selected bar to be below the buttons bar, set it to true
+settings.style.isSelectedBarBelow: Bool = false
+
 // each buttonBar item is a UICollectionView cell of type ButtonBarViewCell
 settings.style.buttonBarItemBackgroundColor: UIColor?
 settings.style.buttonBarItemFont = UIFont.systemFontOfSize(18)

--- a/Sources/ButtonBarPagerTabStripViewController.swift
+++ b/Sources/ButtonBarPagerTabStripViewController.swift
@@ -50,6 +50,7 @@ public struct ButtonBarPagerTabStripSettings {
 
         public var selectedBarBackgroundColor = UIColor.blackColor()
         public var selectedBarHeight: CGFloat = 5
+        public var isSelectedBarBelow = false
         
         public var buttonBarItemBackgroundColor: UIColor?
         public var buttonBarItemFont = UIFont.systemFontOfSize(18)
@@ -134,8 +135,9 @@ public class ButtonBarPagerTabStripViewController: PagerTabStripViewController, 
         buttonBarView.showsHorizontalScrollIndicator = false
         buttonBarView.backgroundColor = settings.style.buttonBarBackgroundColor ?? buttonBarView.backgroundColor
         buttonBarView.selectedBar.backgroundColor = settings.style.selectedBarBackgroundColor
-        
         buttonBarView.selectedBarHeight = settings.style.selectedBarHeight ?? buttonBarView.selectedBarHeight
+        buttonBarView.isSelectedBarBelow = settings.style.isSelectedBarBelow
+		
         // register button bar item cell
         switch buttonBarItemSpec {
         case .NibFile(let nibName, let bundle, _):
@@ -179,6 +181,7 @@ public class ButtonBarPagerTabStripViewController: PagerTabStripViewController, 
     public override func reloadPagerTabStripView() {
         super.reloadPagerTabStripView()
         guard isViewLoaded() else { return }
+        buttonBarView.updateSelectedBarYPosition()
         buttonBarView.reloadData()
         cachedCellWidths = calculateWidths()
         buttonBarView.moveToIndex(currentIndex, animated: false, swipeDirection: .None, pagerScroll: .Yes)

--- a/Sources/ButtonBarView.swift
+++ b/Sources/ButtonBarView.swift
@@ -45,9 +45,16 @@ public class ButtonBarView: UICollectionView {
         return bar
     }()
     
+    public var isSelectedBarBelow = false {
+        didSet {
+            clipsToBounds = !isSelectedBarBelow
+            updateSelectedBarYPosition()
+        }
+    }
+    
     internal var selectedBarHeight: CGFloat = 4 {
         didSet {
-            self.updateSlectedBarYPosition()
+            updateSelectedBarYPosition()
         }
     }
     var selectedBarAlignment: SelectedBarAlignment = .Center
@@ -131,6 +138,13 @@ public class ButtonBarView: UICollectionView {
         }
     }
     
+    public func updateSelectedBarYPosition() {
+        var selectedBarFrame = selectedBar.frame
+        selectedBarFrame.origin.y = frame.size.height - (isSelectedBarBelow ? 0 : selectedBarHeight)
+        selectedBarFrame.size.height = selectedBarHeight
+        selectedBar.frame = selectedBarFrame
+    }
+    
     // MARK: - Helpers
     
     private func updateContentOffset(animated: Bool, pagerScroll: PagerScroll, toFrame: CGRect, toIndex: Int) -> Void {
@@ -163,12 +177,5 @@ public class ButtonBarView: UICollectionView {
         contentOffset = max(0, contentOffset)
         contentOffset = min(contentSize.width - frame.size.width, contentOffset)
         return contentOffset
-    }
-    
-    private func updateSlectedBarYPosition() {
-        var selectedBarFrame = selectedBar.frame
-        selectedBarFrame.origin.y = frame.size.height - selectedBarHeight
-        selectedBarFrame.size.height = selectedBarHeight
-        selectedBar.frame = selectedBarFrame
     }
 }

--- a/XLPagerTabStrip.podspec
+++ b/XLPagerTabStrip.podspec
@@ -11,5 +11,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.ios.source_files = 'Sources/**/*'
   s.ios.frameworks = 'UIKit', 'Foundation'
-  s.resource_bundles = { 'XLPagerTabStrip' => ['Sources/ButtonCell.xib'] }
+  # s.resource_bundles = { 'XLPagerTabStrip' => ['Sources/ButtonCell.xib'] }
 end


### PR DESCRIPTION
# isSelectedBarBelow

The goal of this PR is to introduce a new setting to `ButtonBarPagerTabStripViewController`, which renders the "selected bar" below the buttons bar instead of inside it.

To implement this behaviour, the `ButtonBarView` has a new property `isSelectedBarBelow`, which when set to true, changes `clipsToBounds` to false and update the bar Y position.

`updateSelectedBarYPosition` was updated to set the Y position of the selected bar according to this setting. A typo was fixed too (it was written `updateSlectedBarYPosition`).

An example was implemented and is turned on through a modally presented settings screen, with a `UISwitch` and a update button to change the current behaviour. All other examples were not modified and is working as before.

The resulting layout is this:
![isselectedbarbelow](https://cloud.githubusercontent.com/assets/679503/14415903/8746c916-ff7a-11e5-910c-421220da92f5.png)

README file was updated as well to show how to setup this feature:

``` markdown
// if you want the selected bar to be below the buttons bar, set it to true
settings.style.isSelectedBarBelow: Bool = false
```
