### PR TITLE
Add support for custom ButtonBarViewCell class when using library without IB

### DIFF
--- a/Sources/BaseButtonBarPagerTabStripViewController.swift
+++ b/Sources/BaseButtonBarPagerTabStripViewController.swift
@@ -276,7 +276,7 @@ public class BaseButtonBarPagerTabStripViewController<ButtonBarCellType : UIColl
             let childController = viewController as! IndicatorInfoProvider
             let indicatorInfo = childController.indicatorInfoForPagerTabStrip(self)
             switch buttonBarItemSpec! {
-            case .CellClass(let widthCallback):
+            case .CellClass(_, let widthCallback):
                 let width = widthCallback(indicatorInfo)
                 minimumCellWidths.append(width)
                 collectionViewContentWidth += width

--- a/Sources/ButtonBarPagerTabStripViewController.swift
+++ b/Sources/ButtonBarPagerTabStripViewController.swift
@@ -25,13 +25,13 @@
 import Foundation
 
 public enum ButtonBarItemSpec<CellType: UICollectionViewCell> {
-    
+
     case NibFile(nibName: String, bundle: NSBundle?, width:((IndicatorInfo)-> CGFloat))
-    case CellClass(width:((IndicatorInfo)-> CGFloat))
-    
+    case CellClass(cellClass: ButtonBarViewCell.Type, width:((IndicatorInfo)-> CGFloat))
+
     public var weight: ((IndicatorInfo) -> CGFloat) {
         switch self {
-        case .CellClass(let widthCallback):
+        case .CellClass(_, let widthCallback):
             return widthCallback
         case .NibFile(_, _, let widthCallback):
             return widthCallback
@@ -140,8 +140,8 @@ public class ButtonBarPagerTabStripViewController: PagerTabStripViewController, 
         switch buttonBarItemSpec {
         case .NibFile(let nibName, let bundle, _):
             buttonBarView.registerNib(UINib(nibName: nibName, bundle: bundle), forCellWithReuseIdentifier:"Cell")
-        case .CellClass:
-            buttonBarView.registerClass(ButtonBarViewCell.self, forCellWithReuseIdentifier:"Cell")
+        case .CellClass(let cellClass, _):
+            buttonBarView.registerClass(cellClass, forCellWithReuseIdentifier:"Cell")
         }
         //-
     }
@@ -320,7 +320,7 @@ public class ButtonBarPagerTabStripViewController: PagerTabStripViewController, 
             let childController = viewController as! IndicatorInfoProvider
             let indicatorInfo = childController.indicatorInfoForPagerTabStrip(self)
             switch buttonBarItemSpec {
-            case .CellClass(let widthCallback):
+            case .CellClass(_, let widthCallback):
                 let width = widthCallback(indicatorInfo)
                 minimumCellWidths.append(width)
                 collectionViewContentWidth += width


### PR DESCRIPTION
Hi,
I am using this library without XIBs or Storyboards and encountered an issue with custom `ButtonBarViewCell` subclass. Currently, there is no way to specify other class than `ButtonBarViewCell`. To add subviews to the button, it is required to modify original class.

To fix this, I added `CellClass` parameter to `ButtonBarItemSpec`, so now it is possible to provide own class without modifying `ButtonBarViewCell`.

This way library becomes more flexible as there is no need in changing files to customize the behavior.

However, as Swift doesn't have [https://appventure.me/2015/10/17/advanced-practical-enum-examples/#sec-5-5](default associated values in enums), this pull request introduces a breaking change.

Before, to work without XIBs it was required to provide a ButtonBarItemSpec like this:

``` Swift
    buttonBarItemSpec = ButtonBarItemSpec.CellClass(width: { (info) -> CGFloat in
      return 55
    })
```

Now, the class is to be specified:

``` Swift
    buttonBarItemSpec = ButtonBarItemSpec.CellClass(cellClass: ButtonBarViewCell.self, width: { (info) -> CGFloat in
        return 55
    })
```

Related issues: #105, #114
