### PR TITLE
Make library more open for extension

### DIFF
--- a/Sources/ButtonBarView.swift
+++ b/Sources/ButtonBarView.swift
@@ -51,7 +51,7 @@ public class ButtonBarView: UICollectionView {
         }
     }
     var selectedBarAlignment: SelectedBarAlignment = .Center
-    var selectedIndex = 0
+    public internal(set) var selectedIndex = 0
     
     required public init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)

--- a/Sources/IndicatorInfo.swift
+++ b/Sources/IndicatorInfo.swift
@@ -24,39 +24,15 @@
 
 import Foundation
 
-public struct IndicatorInfo {
+public class IndicatorInfo {
     
     public var title: String
     public var image: UIImage?
     public var highlightedImage: UIImage?
     
-    public init(title: String) {
+    public init(title: String, image: UIImage? = nil, highlightedImage: UIImage? = nil) {
         self.title = title
-    }
-    
-    public init(title: String, image: UIImage?) {
-        self.init(title: title)
         self.image = image
-    }
-    
-    public init(title: String, image: UIImage?, highlightedImage: UIImage?) {
-        self.init(title: title, image: image)
         self.highlightedImage = highlightedImage
-    }
-}
-
-
-extension IndicatorInfo : StringLiteralConvertible {
-    
-    public init(stringLiteral value: String){
-        title = value
-    }
-    
-    public init(extendedGraphemeClusterLiteral value: String){
-        title = value
-    }
-    
-    public init(unicodeScalarLiteral value: String){
-        title = value
     }
 }


### PR DESCRIPTION
When using the library in a more advanced way to dynamically update the ButtonBar labels the library is currently to closed. The proposed changes allow the library user more possibilities and follow the open/close principle in OOP. Structs in swift are not extensible, so the IndicatorInfo struct was replaced by a class.
