### PR TITLE
Fix a crash bug occured by removing unregistered observer

### DIFF
--- a/Sources/TwitterPagerTabStripViewController.swift
+++ b/Sources/TwitterPagerTabStripViewController.swift
@@ -46,6 +46,8 @@ public class TwitterPagerTabStripViewController: PagerTabStripViewController, Pa
         pagerBehaviour = .Progressive(skipIntermediateViewControllers: true, elasticIndicatorLimit: true)
         delegate = self
         datasource = self
+        // keep watching the frame of titleView
+        titleView.addObserver(self, forKeyPath: "frame", options: [.New, .Old], context: nil)
     }
     
     required public init?(coder aDecoder: NSCoder) {
@@ -53,6 +55,8 @@ public class TwitterPagerTabStripViewController: PagerTabStripViewController, Pa
         pagerBehaviour = .Progressive(skipIntermediateViewControllers: true, elasticIndicatorLimit: true)
         delegate = self
         datasource = self
+        // keep watching the frame of titleView
+        titleView.addObserver(self, forKeyPath: "frame", options: [.New, .Old], context: nil)
     }
     
     public override func viewDidLoad() {
@@ -61,10 +65,7 @@ public class TwitterPagerTabStripViewController: PagerTabStripViewController, Pa
         if titleView.superview == nil {
             navigationItem.titleView = titleView
         }
-        
-        // keep watching the frame of titleView
-        titleView.addObserver(self, forKeyPath: "frame", options: [.New, .Old], context: nil)
-        
+
         guard let navigationController = navigationController  else {
             fatalError("TwitterPagerTabStripViewController should be embedded in a UINavigationController")
         }


### PR DESCRIPTION
# Overview

In [Example.xcodeproj](https://github.com/xmartlabs/XLPagerTabStrip/tree/master/Example.xcodeproj), we can see view of [Sources/TwitterPagerTabStripViewController.swift](https://github.com/xmartlabs/XLPagerTabStrip/blob/master/Sources/TwitterPagerTabStripViewController.swift) by following flow.

1. Select `PageTabController Types` cell
2. Select `Twitter` tab

Then the `viewDidLoad` is called and `titleView` lazy stored property which is defined into [Sources/TwitterPagerTabStripViewController.swift](https://github.com/xmartlabs/XLPagerTabStrip/blob/master/Sources/TwitterPagerTabStripViewController.swift) is initialized and added observer for `titleView.frame`.

However, we can select `PageTabController Types` cell and close immediately without showing view of [Sources/TwitterPagerTabStripViewController.swift](https://github.com/xmartlabs/XLPagerTabStrip/blob/master/Sources/TwitterPagerTabStripViewController.swift).
Then the `viewDidLoad` isn't called.
Therefore  crash is occured because remove observer for `titleView.frame` into `deinit()` in spite of didn't register observer.

My proposal is move add observer process to initializer of [Sources/TwitterPagerTabStripViewController.swift](https://github.com/xmartlabs/XLPagerTabStrip/blob/master/Sources/TwitterPagerTabStripViewController.swift).

Please check this PR when you have enough time 🙇 

### How to Reproduction

* Xcode 7.3.1 
* iPhone6s Plus simulator

1. Select `PageTabControllerTypes` cell
2. Select Close button
3. Crash application with error log as below

```
Example[31911:509386] *** Terminating app due to uncaught exception 'NSRangeException', 
reason: 'Cannot remove an observer <Example.TwitterExampleViewController 0x7fb2104d4670>
 for the key path "frame" from <UIView 0x7fb210714550> because it is not registered as an
 observer.'
```