### PR TITLE
Fix issue with scroll view insets

### DIFF
--- a/Sources/PagerTabStripViewController.swift
+++ b/Sources/PagerTabStripViewController.swift
@@ -135,13 +135,13 @@ public class PagerTabStripViewController: UIViewController, UIScrollViewDelegate
             tmpViewControllers[currentIndex] = fromChildVC
             tmpViewControllers[fromIndex] = currentChildVC
             pagerTabStripChildViewControllersForScrolling = tmpViewControllers
-            containerView.setContentOffset(CGPointMake(pageOffsetForChildIndex(index: fromIndex), 0), animated: false)
+            containerView.setContentOffset(CGPointMake(pageOffsetForChildIndex(index: fromIndex), containerView.contentOffset.y), animated: false)
             (navigationController?.view ?? view).userInteractionEnabled = false
-            containerView.setContentOffset(CGPointMake(pageOffsetForChildIndex(index: index), 0), animated: true)
+            containerView.setContentOffset(CGPointMake(pageOffsetForChildIndex(index: index), containerView.contentOffset.y), animated: true)
         }
         else {
             (navigationController?.view ?? view).userInteractionEnabled = false
-            containerView.setContentOffset(CGPointMake(pageOffsetForChildIndex(index: index), 0), animated: animated)
+            containerView.setContentOffset(CGPointMake(pageOffsetForChildIndex(index: index), containerView.contentOffset.y), animated: animated)
         }
     }
     


### PR DESCRIPTION
This fixes an issue when using xibs with automaticallyAdjustsScrollViewInsets (possibly storyboards also?) and UIScrollViews as children of the pager controller. In this case, the `contentOffset.y` of the pager controller is set to `-contentInset.y` of the `UIScrollView` child controller. I don't see a reason why the pager should reset this to 0 instead of preserving whatever the current Y offset is. I also can't imagine a case where this would break - but I haven't tested everything yet.