### PR TITLE
Only disable user interaction when animating (fixes Issue #242)

### DIFF
--- a/Sources/PagerTabStripViewController.swift
+++ b/Sources/PagerTabStripViewController.swift
@@ -138,11 +138,11 @@ open class PagerTabStripViewController: UIViewController, UIScrollViewDelegate {
             tmpViewControllers[fromIndex] = currentChildVC
             pagerTabStripChildViewControllersForScrolling = tmpViewControllers
             containerView.setContentOffset(CGPoint(x: pageOffsetForChild(at: fromIndex), y: 0), animated: false)
-            (navigationController?.view ?? view).isUserInteractionEnabled = false
+            (navigationController?.view ?? view).isUserInteractionEnabled = !animated
             containerView.setContentOffset(CGPoint(x: pageOffsetForChild(at: index), y: 0), animated: true)
         }
         else {
-            (navigationController?.view ?? view).isUserInteractionEnabled = false
+            (navigationController?.view ?? view).isUserInteractionEnabled = !animated
             containerView.setContentOffset(CGPoint(x: pageOffsetForChild(at: index), y: 0), animated: animated)
         }
     }


### PR DESCRIPTION
### What is this PR for?
This PR fixes https://github.com/xmartlabs/XLPagerTabStrip/issues/242.

### What was the source of the problem?
When `moveToViewController(at: Int, animated: Bool)` or `moveTo(viewController: UIViewController, animated: Bool)` was called, user interaction was disabled to prevent the user from interacting with the UI in the middle of a transition. Then, in `scrollViewDidEndScrollingAnimation(_:UIScrollView)`, user interaction would be enabled again. However, when passing `false` for the`animated` parameter, this method does not get called and user interaction won't be enabled again.

### What's the fix for the problem?
The fix is simple. We don't need to disable user interaction when the transition is not animated since the `contentOffset` of the scroll view gets set immediately. I tested it and can I can confirm that it works now.

### How to test these changes
In the [corresponding issue](https://github.com/xmartlabs/XLPagerTabStrip/issues/242), you will find a link to an example project which demonstrates the issue. Run it and tap the bar button item to confirm the issue. Then open the `Cartfile` and specify this branch:
```
github "raphaklr/XLPagerTabStrip" "fix/user_interaction_disabled_when_not_animating"
```
Run
```
carthage update --platform ios
```
, build the project and see the issue fixed.

@mtnbarreto @mats-claassen please review and merge 🙂