### PR TITLE
fix carthage linking error for ButtonBarViewCell

### DIFF
--- a/Sources/ButtonBarViewCell.swift
+++ b/Sources/ButtonBarViewCell.swift
@@ -26,14 +26,18 @@ import Foundation
 
 open class ButtonBarViewCell: UICollectionViewCell {
     
-    @IBOutlet open var imageView: UIImageView!
-    @IBOutlet open lazy var label: UILabel! = { [unowned self] in
-        let label = UILabel(frame: self.contentView.bounds)
+    @IBOutlet weak open var imageView: UIImageView!
+    @IBOutlet weak open var label: UILabel!
+    
+    open override func awakeFromNib() {
+        super.awakeFromNib()
+        
+        label = label ?? UILabel()
+        label.frame = self.contentView.bounds
         label.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         label.textAlignment = .center
         label.font = UIFont.boldSystemFont(ofSize: 14.0)
-        return label
-    }()
+    }
     
     open override func willMove(toSuperview newSuperview: UIView?) {
         super.willMove(toSuperview: newSuperview)

--- a/Sources/ButtonBarViewCell.swift
+++ b/Sources/ButtonBarViewCell.swift
@@ -32,17 +32,18 @@ open class ButtonBarViewCell: UICollectionViewCell {
     open override func awakeFromNib() {
         super.awakeFromNib()
         
-        label = label ?? UILabel()
-        label.frame = self.contentView.bounds
-        label.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-        label.textAlignment = .center
-        label.font = UIFont.boldSystemFont(ofSize: 14.0)
+        let labelAux = label ?? UILabel()
+        labelAux.frame = self.contentView.bounds
+        labelAux.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        labelAux.textAlignment = .center
+        labelAux.font = UIFont.boldSystemFont(ofSize: 14.0)
+        label = labelAux
     }
     
     open override func willMove(toSuperview newSuperview: UIView?) {
         super.willMove(toSuperview: newSuperview)
         
-        if label.superview != nil {
+        if label?.superview != nil {
             contentView.addSubview(label)
         }
     }


### PR DESCRIPTION
I need to customize the display of the ButtonBarViewCell, but when I try to compile with Xcode 8 I got:

```
Undefined symbols for architecture x86_64:
  "direct field offset for XLPagerTabStrip.ButtonBarViewCell.(label.storage in _7CD38FC719B5145B44845BC9A2FA5AB5) : __ObjC.UILabel!?", referenced from:
      XLPagerTabStrip.ButtonBarViewCell.label.setter : __ObjC.UILabel! in TBPagerCollectionViewCell.o
      XLPagerTabStrip.ButtonBarViewCell.(label.materializeForSet : __ObjC.UILabel!).(closure #1) in TBPagerCollectionViewCell.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

Then I fixed it with issue #227
