### PR TITLE
Allow customisation of selected bar frame animation

### DIFF
--- a/Example/Example/ButtonBarExampleViewController.swift
+++ b/Example/Example/ButtonBarExampleViewController.swift
@@ -34,6 +34,30 @@ class ButtonBarExampleViewController: ButtonBarPagerTabStripViewController {
         
         buttonBarView.selectedBar.backgroundColor = .orange
         buttonBarView.backgroundColor = UIColor(red: 7/255, green: 185/255, blue: 155/255, alpha: 1)
+        buttonBarView.selectedBarMoveAnimation = { selectedBar, selectedBarFrame in
+            let initialFrame = selectedBar.frame
+            let movingLeft = initialFrame.origin.x > selectedBarFrame.origin.x
+            UIView.animate(withDuration: 0.20, animations: {
+                if movingLeft {
+                    let origin = selectedBarFrame.origin
+                    let size = CGSize(width: initialFrame.maxX - selectedBarFrame.minX, height: selectedBarFrame.height)
+                    selectedBar.frame = CGRect(origin: origin, size: size)
+                }
+                else {
+                    let origin = initialFrame.origin
+                    let size = CGSize(width: selectedBarFrame.maxX - initialFrame.minX, height: selectedBarFrame.height)
+                    selectedBar.frame = CGRect(origin: origin, size: size)
+                }
+            }, completion: { completed in
+                guard completed else {
+                    selectedBar.frame = selectedBarFrame
+                    return
+                }
+                UIView.animate(withDuration: 0.20, animations: {
+                    selectedBar.frame = selectedBarFrame
+                })
+            })
+        }
     }
     
     // MARK: - PagerTabStripDataSource

--- a/Sources/ButtonBarView.swift
+++ b/Sources/ButtonBarView.swift
@@ -53,6 +53,12 @@ open class ButtonBarView: UICollectionView {
     var selectedBarAlignment: SelectedBarAlignment = .center
     var selectedIndex = 0
     
+    open var selectedBarMoveAnimation: (UIView, CGRect) -> Void = { (selectedBar, selectedBarFrame) in
+        UIView.animate(withDuration: 0.3, animations: {
+            selectedBar.frame = selectedBarFrame
+        })
+    }
+    
     required public init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         addSubview(selectedBar)
@@ -122,9 +128,7 @@ open class ButtonBarView: UICollectionView {
         selectedBarFrame.origin.x = selectedCellFrame.origin.x
         
         if animated {
-            UIView.animate(withDuration: 0.3, animations: { [weak self] in
-                self?.selectedBar.frame = selectedBarFrame
-            })
+            selectedBarMoveAnimation(selectedBar, selectedBarFrame)
         }
         else {
             selectedBar.frame = selectedBarFrame


### PR DESCRIPTION
This change allows customisation of the animation when the selected bar frame moves from previous selection to the current one. By default it will perform the current `UIView` standard transition, but it can be easily replaced by setting the `selectedBarMoveAnimation` of the `ButtonBarView` instance in the controller.

For example, the following code (included in the `ButtonBarExampleViewController`):

    buttonBarView.selectedBarMoveAnimation = { selectedBar, selectedBarFrame in
        let initialFrame = selectedBar.frame
        let movingLeft = initialFrame.origin.x > selectedBarFrame.origin.x
        UIView.animate(withDuration: 0.20, animations: {
            if movingLeft {
                let origin = selectedBarFrame.origin
                let size = CGSize(width: initialFrame.maxX - selectedBarFrame.minX, height: selectedBarFrame.height)
                selectedBar.frame = CGRect(origin: origin, size: size)
            }
            else {
                let origin = initialFrame.origin
                let size = CGSize(width: selectedBarFrame.maxX - initialFrame.minX, height: selectedBarFrame.height)
                selectedBar.frame = CGRect(origin: origin, size: size)
            }
        }, completion: { completed in
            guard completed else {
                selectedBar.frame = selectedBarFrame
                return
            }
            UIView.animate(withDuration: 0.20, animations: {
                selectedBar.frame = selectedBarFrame
            })
        })
    }

Will obtain this animation:
![](https://i.imgur.com/kkKtBFr.gif)