### PR TITLE
Reload not visible cells when changing current child controller

### DIFF
--- a/Sources/ButtonBarPagerTabStripViewController.swift
+++ b/Sources/ButtonBarPagerTabStripViewController.swift
@@ -222,9 +222,11 @@ open class ButtonBarPagerTabStripViewController: PagerTabStripViewController, Pa
         buttonBarView.moveTo(index: toIndex, animated: true, swipeDirection: toIndex < fromIndex ? .right : .left, pagerScroll: .yes)
         
         if let changeCurrentIndex = changeCurrentIndex {
-            let oldCell = buttonBarView.cellForItem(at: IndexPath(item: currentIndex != fromIndex ? fromIndex : toIndex, section: 0)) as? ButtonBarViewCell
-            let newCell = buttonBarView.cellForItem(at: IndexPath(item: currentIndex, section: 0)) as? ButtonBarViewCell
-            changeCurrentIndex(oldCell, newCell, true)
+            let oldIndexPath = IndexPath(item: currentIndex != fromIndex ? fromIndex : toIndex, section: 0)
+            let newIndexPath = IndexPath(item: currentIndex, section: 0)
+
+            let cells = cellForItems(at: [oldIndexPath, newIndexPath])
+            changeCurrentIndex(cells.first!, cells.last!, true)
         }
     }
 
@@ -232,12 +234,31 @@ open class ButtonBarPagerTabStripViewController: PagerTabStripViewController, Pa
         guard shouldUpdateButtonBarView else { return }
         buttonBarView.move(fromIndex: fromIndex, toIndex: toIndex, progressPercentage: progressPercentage, pagerScroll: .yes)
         if let changeCurrentIndexProgressive = changeCurrentIndexProgressive {
-            let oldCell = buttonBarView.cellForItem(at: IndexPath(item: currentIndex != fromIndex ? fromIndex : toIndex, section: 0)) as? ButtonBarViewCell
-            let newCell = buttonBarView.cellForItem(at: IndexPath(item: currentIndex, section: 0)) as? ButtonBarViewCell
-            changeCurrentIndexProgressive(oldCell, newCell, progressPercentage, indexWasChanged, true)
+            let oldIndexPath = IndexPath(item: currentIndex != fromIndex ? fromIndex : toIndex, section: 0)
+            let newIndexPath = IndexPath(item: currentIndex, section: 0)
+
+            let cells = cellForItems(at: [oldIndexPath, newIndexPath])
+            changeCurrentIndexProgressive(cells.first!, cells.last!, progressPercentage, indexWasChanged, true)
         }
     }
-    
+
+    private func cellForItems(at indexPaths: [IndexPath], reloadIfNotVisible reload: Bool = true) -> [ButtonBarViewCell?] {
+        let cells = indexPaths.map { buttonBarView.cellForItem(at: $0) as? ButtonBarViewCell }
+
+        if reload {
+            let indexPathsToReload = cells.enumerated()
+                .flatMap { index, cell in
+                    return cell == nil ? indexPaths[index] : nil
+                }
+                .flatMap {
+                    return ($0.item >= 0 && $0.item < buttonBarView.numberOfItems(inSection: $0.section)) ? $0 : nil
+                }
+            buttonBarView.reloadItems(at: indexPathsToReload)
+        }
+
+        return cells
+    }
+
     // MARK: - UICollectionViewDelegateFlowLayut
     
     open func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAtIndexPath indexPath: IndexPath) -> CGSize {

--- a/Sources/ButtonBarPagerTabStripViewController.swift
+++ b/Sources/ButtonBarPagerTabStripViewController.swift
@@ -250,8 +250,8 @@ open class ButtonBarPagerTabStripViewController: PagerTabStripViewController, Pa
                 .flatMap { index, cell in
                     return cell == nil ? indexPaths[index] : nil
                 }
-                .flatMap {
-                    return ($0.item >= 0 && $0.item < buttonBarView.numberOfItems(inSection: $0.section)) ? $0 : nil
+                .flatMap { (indexPath: IndexPath) -> IndexPath? in
+                    return (indexPath.item >= 0 && indexPath.item < buttonBarView.numberOfItems(inSection: indexPath.section)) ? indexPath : nil
                 }
             buttonBarView.reloadItems(at: indexPathsToReload)
         }


### PR DESCRIPTION
Fixes issues #343, #338 

The issue was that the collection view doesn't return the cells that are not visible, in such cases the cells weren't neither updated nor reloaded. So, what this changes do is, if a cell is not currently visible and its child controller was moved, then reload it.

## UI
* How to reproduce the issue:
![issue](https://cloud.githubusercontent.com/assets/4791678/25547565/3526dda0-2c3e-11e7-8670-e8ce79e6eb03.gif)

* The issue is solved:
![no_issue](https://cloud.githubusercontent.com/assets/4791678/25547566/35476430-2c3e-11e7-9d89-15b15454cb46.gif)
