### PR TITLE
fix to always update lastContentOffset when scrolling

### DIFF
--- a/Sources/PagerTabStripViewController.swift
+++ b/Sources/PagerTabStripViewController.swift
@@ -305,13 +305,13 @@ open class PagerTabStripViewController: UIViewController, UIScrollViewDelegate {
     open func scrollViewDidScroll(_ scrollView: UIScrollView) {
         if containerView == scrollView {
             updateContent()
+            lastContentOffset = scrollView.contentOffset.x
         }
     }
     
     open func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
         if containerView == scrollView {
             lastPageNumber = pageFor(contentOffset: scrollView.contentOffset.x)
-            lastContentOffset = scrollView.contentOffset.x
         }
     }
     


### PR DESCRIPTION
When using ButtonBarPagerTabStripViewController, even if I click button, since lastContentOffset was not updated, I will fix it