### PR TITLE
Fixes #357

### DIFF
--- a/Sources/ButtonBarPagerTabStripViewController.swift
+++ b/Sources/ButtonBarPagerTabStripViewController.swift
@@ -266,7 +266,7 @@ open class ButtonBarPagerTabStripViewController: PagerTabStripViewController, Pa
         return cells
     }
 
-    // MARK: - UICollectionViewDelegateFlowLayut
+    // MARK: - UICollectionViewDelegateFlowLayout
     
     open func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAtIndexPath indexPath: IndexPath) -> CGSize {
         guard let cellWidthValue = cachedCellWidths?[indexPath.row] else {


### PR DESCRIPTION
When the `moveToViewController(..)` function was called but the view wasn't visible, the index of the target viewcontroller got "saved" to the `currentIndex` property for further use. When the view indeed became visible this wasn't checked and the change to `currentIndex` was vain, issue #357.

This PR adds the `preCurrentIndex` with the sole purpose of handling this case, the currentIndex gets changed when the view isn't visible.
The index of the target viewcontroller gets "saved" to this property and then in the `viewDidAppear` function it gets checked against `currentIndex` to determine if the current child vc needs to be updated.

The downside of this approach is that the child gets updated **after** the view appears.