### PR TITLE
Fixes #322

### DIFF
--- a/Sources/ButtonBarView.swift
+++ b/Sources/ButtonBarView.swift
@@ -112,8 +112,7 @@ open class ButtonBarView: UICollectionView {
             targetContentOffset = fromContentOffset + ((toContentOffset - fromContentOffset) * progressPercentage)
         }
         
-        let animated = abs(contentOffset.x - targetContentOffset) > 30 || (fromIndex == toIndex)
-        setContentOffset(CGPoint(x: targetContentOffset, y: 0), animated: animated)
+        setContentOffset(CGPoint(x: targetContentOffset, y: 0), animated: false)
     }
     
     open func updateSelectedBarPosition(_ animated: Bool, swipeDirection: SwipeDirection, pagerScroll: PagerScroll) -> Void {


### PR DESCRIPTION
Fixes #322, the `contentOffset` of the `ButtonBarView` was being set animated when the swipe velocity was _high_, this caused `UIKit` to set the `contentOffset` with a constant velocity and resulted in the actual scroll to be delayed. 