### PR TITLE
Fixes in moveToViewController

### DIFF
--- a/Sources/PagerTabStripViewController.swift
+++ b/Sources/PagerTabStripViewController.swift
@@ -149,8 +149,22 @@ open class PagerTabStripViewController: UIViewController, UIScrollViewDelegate {
     }
 
     open func moveToViewController(at index: Int, animated: Bool = true) {
-        guard isViewLoaded && view.window != nil && currentIndex != index else {
-            preCurrentIndex = index
+        guard currentIndex != index else { return }
+        
+        guard isViewLoaded, viewControllers.count != 0 else {
+            currentIndex = index
+            return
+        }
+        
+        guard view.window != nil else {
+            if animated {
+                preCurrentIndex = index
+            } else {
+                let step = (currentIndex < index) ? 1 : -1
+                for subindex in stride(from: currentIndex+step, through: index, by: step){
+                    containerView.setContentOffset(CGPoint(x: pageOffsetForChild(at: subindex), y: 0), animated: animated)
+                }
+            }
             return
         }
 


### PR DESCRIPTION
Restored option to call `moveToViewController` before `viewDidLoad` to change the initial tab.

A call to `moveToViewController` with the view not showing was ignoring the `animated` parameter.

