### PR TITLE
Bottom Border added to BarPagerTabStripViewController, ButtonBarPagerTabStripViewController

### DIFF
--- a/Sources/BarPagerTabStripViewController.swift
+++ b/Sources/BarPagerTabStripViewController.swift
@@ -26,48 +26,53 @@ import Foundation
 import UIKit
 
 public struct BarPagerTabStripSettings {
-
+    
     public struct Style {
         public var barBackgroundColor: UIColor?
         public var selectedBarBackgroundColor: UIColor?
         public var barHeight: CGFloat = 5 // barHeight is ony set up when the bar is created programatically and not using storyboards or xib files.
+        public var bottomBorderHeight: CGFloat = 0 // bottomBorderHeight
+        public var bottomBorderColor: UIColor?
     }
-
+    
     public var style = Style()
 }
 
 open class BarPagerTabStripViewController: PagerTabStripViewController, PagerTabStripDataSource, PagerTabStripIsProgressiveDelegate {
-
+    
     public var settings = BarPagerTabStripSettings()
-
+    
     @IBOutlet weak public var barView: BarView!
-
+    
     required public init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         delegate = self
         datasource = self
     }
-
+    
     public override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
         super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
         delegate = self
         datasource = self
     }
-
+    
     open override func viewDidLoad() {
         super.viewDidLoad()
         barView = barView ?? {
             let barView = BarView(frame: CGRect(x: 0, y: 0, width: view.frame.size.width, height: settings.style.barHeight))
+            let bottomBorderView = UIView(frame: CGRect(x: 0, y: barView.frame.height - settings.style.bottomBorderHeight, width: barView.frame.width, height: settings.style.bottomBorderHeight))
+            bottomBorderView.backgroundColor = settings.style.bottomBorderColor ?? .blue
+            barView.addSubview(bottomBorderView)
             barView.autoresizingMask = .flexibleWidth
             barView.backgroundColor = .black
             barView.selectedBar.backgroundColor = .white
             return barView
-        }()
-
+            }()
+        
         barView.backgroundColor = settings.style.barBackgroundColor ?? barView.backgroundColor
         barView.selectedBar.backgroundColor = settings.style.selectedBarBackgroundColor ?? barView.selectedBar.backgroundColor
     }
-
+    
     open override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         if barView.superview == nil {
@@ -76,22 +81,22 @@ open class BarPagerTabStripViewController: PagerTabStripViewController, PagerTab
         barView.optionsCount = viewControllers.count
         barView.moveTo(index: currentIndex, animated: false)
     }
-
+    
     open override func reloadPagerTabStripView() {
         super.reloadPagerTabStripView()
         barView.optionsCount = viewControllers.count
-        if isViewLoaded {
+        if isViewLoaded{
             barView.moveTo(index: currentIndex, animated: false)
         }
     }
-
+    
     // MARK: - PagerTabStripDelegate
-
+    
     open func updateIndicator(for viewController: PagerTabStripViewController, fromIndex: Int, toIndex: Int, withProgressPercentage progressPercentage: CGFloat, indexWasChanged: Bool) {
-
+        
         barView.move(fromIndex: fromIndex, toIndex: toIndex, progressPercentage: progressPercentage)
     }
-
+    
     open func updateIndicator(for viewController: PagerTabStripViewController, fromIndex: Int, toIndex: Int) {
         barView.moveTo(index: toIndex, animated: true)
     }

--- a/Sources/ButtonBarPagerTabStripViewController.swift
+++ b/Sources/ButtonBarPagerTabStripViewController.swift
@@ -25,10 +25,10 @@
 import Foundation
 
 public enum ButtonBarItemSpec<CellType: UICollectionViewCell> {
-
+    
     case nibFile(nibName: String, bundle: Bundle?, width:((IndicatorInfo)-> CGFloat))
     case cellClass(width:((IndicatorInfo)-> CGFloat))
-
+    
     public var weight: ((IndicatorInfo) -> CGFloat) {
         switch self {
         case .cellClass(let widthCallback):
@@ -40,22 +40,26 @@ public enum ButtonBarItemSpec<CellType: UICollectionViewCell> {
 }
 
 public struct ButtonBarPagerTabStripSettings {
-
+    
     public struct Style {
         public var buttonBarBackgroundColor: UIColor?
         public var buttonBarMinimumInteritemSpacing: CGFloat?
         public var buttonBarMinimumLineSpacing: CGFloat?
         public var buttonBarLeftContentInset: CGFloat?
         public var buttonBarRightContentInset: CGFloat?
-
+        
         public var selectedBarBackgroundColor = UIColor.black
         public var selectedBarHeight: CGFloat = 5
         public var selectedBarVerticalAlignment: SelectedBarVerticalAlignment = .bottom
-
+        
         public var buttonBarItemBackgroundColor: UIColor?
         public var buttonBarItemFont = UIFont.systemFont(ofSize: 18)
         public var buttonBarItemLeftRightMargin: CGFloat = 8
         public var buttonBarItemTitleColor: UIColor?
+        
+        public var bottomBorderHeight: CGFloat = 0 // bottomBorderHeight
+        public var bottomBorderColor: UIColor?
+        
         @available(*, deprecated: 7.0.0) public var buttonBarItemsShouldFillAvailiableWidth: Bool {
             set {
                 buttonBarItemsShouldFillAvailableWidth = newValue
@@ -68,64 +72,69 @@ public struct ButtonBarPagerTabStripSettings {
         // only used if button bar is created programaticaly and not using storyboards or nib files
         public var buttonBarHeight: CGFloat?
     }
-
+    
     public var style = Style()
 }
 
 open class ButtonBarPagerTabStripViewController: PagerTabStripViewController, PagerTabStripDataSource, PagerTabStripIsProgressiveDelegate, UICollectionViewDelegate, UICollectionViewDataSource {
-
+    
     public var settings = ButtonBarPagerTabStripSettings()
-
+    
     public var buttonBarItemSpec: ButtonBarItemSpec<ButtonBarViewCell>!
-
+    
     public var changeCurrentIndex: ((_ oldCell: ButtonBarViewCell?, _ newCell: ButtonBarViewCell?, _ animated: Bool) -> Void)?
     public var changeCurrentIndexProgressive: ((_ oldCell: ButtonBarViewCell?, _ newCell: ButtonBarViewCell?, _ progressPercentage: CGFloat, _ changeCurrentIndex: Bool, _ animated: Bool) -> Void)?
-
+    
     @IBOutlet public weak var buttonBarView: ButtonBarView!
-
+    
     lazy private var cachedCellWidths: [CGFloat]? = { [unowned self] in
         return self.calculateWidths()
-    }()
-
+        }()
+    
     override public init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
         super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
         delegate = self
         datasource = self
     }
-
+    
     required public init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         delegate = self
         datasource = self
     }
-
+    
     open override func viewDidLoad() {
         super.viewDidLoad()
         buttonBarItemSpec = .nibFile(nibName: "ButtonCell", bundle: Bundle(for: ButtonBarViewCell.self), width: { [weak self] (childItemInfo) -> CGFloat in
-                let label = UILabel()
-                label.translatesAutoresizingMaskIntoConstraints = false
-                label.font = self?.settings.style.buttonBarItemFont
-                label.text = childItemInfo.title
-                let labelSize = label.intrinsicContentSize
-                return labelSize.width + (self?.settings.style.buttonBarItemLeftRightMargin ?? 8) * 2
+            let label = UILabel()
+            label.translatesAutoresizingMaskIntoConstraints = false
+            label.font = self?.settings.style.buttonBarItemFont
+            label.text = childItemInfo.title
+            let labelSize = label.intrinsicContentSize
+            return labelSize.width + (self?.settings.style.buttonBarItemLeftRightMargin ?? 8) * 2
         })
-
+        
         let buttonBarViewAux = buttonBarView ?? {
-                let flowLayout = UICollectionViewFlowLayout()
-                flowLayout.scrollDirection = .horizontal
-                let buttonBarHeight = settings.style.buttonBarHeight ?? 44
-                let buttonBar = ButtonBarView(frame: CGRect(x: 0, y: 0, width: view.frame.size.width, height: buttonBarHeight), collectionViewLayout: flowLayout)
-                buttonBar.backgroundColor = .orange
-                buttonBar.selectedBar.backgroundColor = .black
-                buttonBar.autoresizingMask = .flexibleWidth
-                var newContainerViewFrame = containerView.frame
-                newContainerViewFrame.origin.y = buttonBarHeight
-                newContainerViewFrame.size.height = containerView.frame.size.height - (buttonBarHeight - containerView.frame.origin.y)
-                containerView.frame = newContainerViewFrame
-                return buttonBar
+            let flowLayout = UICollectionViewFlowLayout()
+            flowLayout.scrollDirection = .horizontal
+            let buttonBarHeight = settings.style.buttonBarHeight ?? 44
+            let buttonBar = ButtonBarView(frame: CGRect(x: 0, y: 0, width: view.frame.size.width, height: buttonBarHeight), collectionViewLayout: flowLayout)
+            
+            let bottomBorderView = UIView(frame: CGRect(x: 0, y: buttonBar.frame.height - settings.style.bottomBorderHeight, width: buttonBar.frame.width, height: settings.style.bottomBorderHeight))
+            bottomBorderView.backgroundColor = settings.style.bottomBorderColor ?? .blue
+            buttonBar.addSubview(bottomBorderView)
+            
+            buttonBar.backgroundColor = .orange
+            buttonBar.selectedBar.backgroundColor = .black
+            buttonBar.autoresizingMask = .flexibleWidth
+            var newContainerViewFrame = containerView.frame
+            newContainerViewFrame.origin.y = buttonBarHeight
+            newContainerViewFrame.size.height = containerView.frame.size.height - (buttonBarHeight - containerView.frame.origin.y)
+            containerView.frame = newContainerViewFrame
+            return buttonBar
             }()
         buttonBarView = buttonBarViewAux
-
+        
         if buttonBarView.superview == nil {
             view.addSubview(buttonBarView)
         }
@@ -142,14 +151,14 @@ open class ButtonBarPagerTabStripViewController: PagerTabStripViewController, Pa
         flowLayout.minimumLineSpacing = settings.style.buttonBarMinimumLineSpacing ?? flowLayout.minimumLineSpacing
         let sectionInset = flowLayout.sectionInset
         flowLayout.sectionInset = UIEdgeInsets(top: sectionInset.top, left: settings.style.buttonBarLeftContentInset ?? sectionInset.left, bottom: sectionInset.bottom, right: settings.style.buttonBarRightContentInset ?? sectionInset.right)
-
+        
         buttonBarView.showsHorizontalScrollIndicator = false
         buttonBarView.backgroundColor = settings.style.buttonBarBackgroundColor ?? buttonBarView.backgroundColor
         buttonBarView.selectedBar.backgroundColor = settings.style.selectedBarBackgroundColor
-
+        
         buttonBarView.selectedBarHeight = settings.style.selectedBarHeight
         buttonBarView.selectedBarVerticalAlignment = settings.style.selectedBarVerticalAlignment
-
+        
         // register button bar item cell
         switch buttonBarItemSpec! {
         case .nibFile(let nibName, let bundle, _):
@@ -159,17 +168,17 @@ open class ButtonBarPagerTabStripViewController: PagerTabStripViewController, Pa
         }
         //-
     }
-
+    
     open override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         buttonBarView.layoutIfNeeded()
     }
-
+    
     open override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
-
+        
         guard isViewAppearing || isViewRotating else { return }
-
+        
         // Force the UICollectionViewFlowLayout to get laid out again with the new size if
         // a) The view is appearing.  This ensures that
         //    collectionView:layout:sizeForItemAtIndexPath: is called for a second time
@@ -187,9 +196,9 @@ open class ButtonBarPagerTabStripViewController: PagerTabStripViewController, Pa
         // tab/cell may end up either skewed or off screen after a rotation otherwise)
         buttonBarView.moveTo(index: currentIndex, animated: false, swipeDirection: .none, pagerScroll: .scrollOnlyIfOutOfScreen)
     }
-
+    
     // MARK: - Public Methods
-
+    
     open override func reloadPagerTabStripView() {
         super.reloadPagerTabStripView()
         guard isViewLoaded else { return }
@@ -197,57 +206,57 @@ open class ButtonBarPagerTabStripViewController: PagerTabStripViewController, Pa
         cachedCellWidths = calculateWidths()
         buttonBarView.moveTo(index: currentIndex, animated: false, swipeDirection: .none, pagerScroll: .yes)
     }
-
+    
     open func calculateStretchedCellWidths(_ minimumCellWidths: [CGFloat], suggestedStretchedCellWidth: CGFloat, previousNumberOfLargeCells: Int) -> CGFloat {
         var numberOfLargeCells = 0
         var totalWidthOfLargeCells: CGFloat = 0
-
+        
         for minimumCellWidthValue in minimumCellWidths where minimumCellWidthValue > suggestedStretchedCellWidth {
             totalWidthOfLargeCells += minimumCellWidthValue
             numberOfLargeCells += 1
         }
-
+        
         guard numberOfLargeCells > previousNumberOfLargeCells else { return suggestedStretchedCellWidth }
-
+        
         let flowLayout = buttonBarView.collectionViewLayout as! UICollectionViewFlowLayout // swiftlint:disable:this force_cast
         let collectionViewAvailiableWidth = buttonBarView.frame.size.width - flowLayout.sectionInset.left - flowLayout.sectionInset.right
         let numberOfCells = minimumCellWidths.count
         let cellSpacingTotal = CGFloat(numberOfCells - 1) * flowLayout.minimumLineSpacing
-
+        
         let numberOfSmallCells = numberOfCells - numberOfLargeCells
         let newSuggestedStretchedCellWidth = (collectionViewAvailiableWidth - totalWidthOfLargeCells - cellSpacingTotal) / CGFloat(numberOfSmallCells)
-
+        
         return calculateStretchedCellWidths(minimumCellWidths, suggestedStretchedCellWidth: newSuggestedStretchedCellWidth, previousNumberOfLargeCells: numberOfLargeCells)
     }
-
+    
     open func updateIndicator(for viewController: PagerTabStripViewController, fromIndex: Int, toIndex: Int) {
         guard shouldUpdateButtonBarView else { return }
         buttonBarView.moveTo(index: toIndex, animated: false, swipeDirection: toIndex < fromIndex ? .right : .left, pagerScroll: .yes)
-
+        
         if let changeCurrentIndex = changeCurrentIndex {
             let oldIndexPath = IndexPath(item: currentIndex != fromIndex ? fromIndex : toIndex, section: 0)
             let newIndexPath = IndexPath(item: currentIndex, section: 0)
-
+            
             let cells = cellForItems(at: [oldIndexPath, newIndexPath], reloadIfNotVisible: collectionViewDidLoad)
             changeCurrentIndex(cells.first!, cells.last!, true)
         }
     }
-
+    
     open func updateIndicator(for viewController: PagerTabStripViewController, fromIndex: Int, toIndex: Int, withProgressPercentage progressPercentage: CGFloat, indexWasChanged: Bool) {
         guard shouldUpdateButtonBarView else { return }
         buttonBarView.move(fromIndex: fromIndex, toIndex: toIndex, progressPercentage: progressPercentage, pagerScroll: .yes)
         if let changeCurrentIndexProgressive = changeCurrentIndexProgressive {
             let oldIndexPath = IndexPath(item: currentIndex != fromIndex ? fromIndex : toIndex, section: 0)
             let newIndexPath = IndexPath(item: currentIndex, section: 0)
-
+            
             let cells = cellForItems(at: [oldIndexPath, newIndexPath], reloadIfNotVisible: collectionViewDidLoad)
             changeCurrentIndexProgressive(cells.first!, cells.last!, progressPercentage, indexWasChanged, true)
         }
     }
-
+    
     private func cellForItems(at indexPaths: [IndexPath], reloadIfNotVisible reload: Bool = true) -> [ButtonBarViewCell?] {
         let cells = indexPaths.map { buttonBarView.cellForItem(at: $0) as? ButtonBarViewCell }
-
+        
         if reload {
             let indexPathsToReload = cells.enumerated()
                 .flatMap { index, cell in
@@ -255,36 +264,36 @@ open class ButtonBarPagerTabStripViewController: PagerTabStripViewController, Pa
                 }
                 .flatMap { (indexPath: IndexPath) -> IndexPath? in
                     return (indexPath.item >= 0 && indexPath.item < buttonBarView.numberOfItems(inSection: indexPath.section)) ? indexPath : nil
-                }
-
+            }
+            
             if !indexPathsToReload.isEmpty {
                 buttonBarView.reloadItems(at: indexPathsToReload)
             }
         }
-
+        
         return cells
     }
-
+    
     // MARK: - UICollectionViewDelegateFlowLayut
-
+    
     open func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAtIndexPath indexPath: IndexPath) -> CGSize {
         guard let cellWidthValue = cachedCellWidths?[indexPath.row] else {
             fatalError("cachedCellWidths for \(indexPath.row) must not be nil")
         }
         return CGSize(width: cellWidthValue, height: collectionView.frame.size.height)
     }
-
+    
     open func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         guard indexPath.item != currentIndex else { return }
-
+        
         buttonBarView.moveTo(index: indexPath.item, animated: true, swipeDirection: .none, pagerScroll: .yes)
         shouldUpdateButtonBarView = false
-
+        
         let oldIndexPath = IndexPath(item: currentIndex, section: 0)
         let newIndexPath = IndexPath(item: indexPath.item, section: 0)
-
+        
         let cells = cellForItems(at: [oldIndexPath, newIndexPath], reloadIfNotVisible: collectionViewDidLoad)
-
+        
         if pagerBehaviour.isProgressiveIndicator {
             if let changeCurrentIndexProgressive = changeCurrentIndexProgressive {
                 changeCurrentIndexProgressive(cells.first!, cells.last!, 1, true, true)
@@ -296,23 +305,23 @@ open class ButtonBarPagerTabStripViewController: PagerTabStripViewController, Pa
         }
         moveToViewController(at: indexPath.item)
     }
-
+    
     // MARK: - UICollectionViewDataSource
-
+    
     open func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return viewControllers.count
     }
-
+    
     open func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "Cell", for: indexPath) as? ButtonBarViewCell else {
             fatalError("UICollectionViewCell should be or extend from ButtonBarViewCell")
         }
-
+        
         collectionViewDidLoad = true
-
+        
         let childController = viewControllers[indexPath.item] as! IndicatorInfoProvider // swiftlint:disable:this force_cast
         let indicatorInfo = childController.indicatorInfo(for: self)
-
+        
         cell.label.text = indicatorInfo.title
         cell.label.font = settings.style.buttonBarItemFont
         cell.label.textColor = settings.style.buttonBarItemTitleColor ?? cell.label.textColor
@@ -324,9 +333,9 @@ open class ButtonBarPagerTabStripViewController: PagerTabStripViewController, Pa
         if let highlightedImage = indicatorInfo.highlightedImage {
             cell.imageView.highlightedImage = highlightedImage
         }
-
+        
         configureCell(cell, indicatorInfo: indicatorInfo)
-
+        
         if pagerBehaviour.isProgressiveIndicator {
             if let changeCurrentIndexProgressive = changeCurrentIndexProgressive {
                 changeCurrentIndexProgressive(currentIndex == indexPath.item ? nil : cell, currentIndex == indexPath.item ? cell : nil, 1, true, false)
@@ -338,26 +347,26 @@ open class ButtonBarPagerTabStripViewController: PagerTabStripViewController, Pa
         }
         return cell
     }
-
+    
     // MARK: - UIScrollViewDelegate
-
+    
     open override func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
         super.scrollViewDidEndScrollingAnimation(scrollView)
-
+        
         guard scrollView == containerView else { return }
         shouldUpdateButtonBarView = true
     }
-
+    
     open func configureCell(_ cell: ButtonBarViewCell, indicatorInfo: IndicatorInfo) {
     }
-
+    
     private func calculateWidths() -> [CGFloat] {
         let flowLayout = buttonBarView.collectionViewLayout as! UICollectionViewFlowLayout // swiftlint:disable:this force_cast
         let numberOfCells = viewControllers.count
-
+        
         var minimumCellWidths = [CGFloat]()
         var collectionViewContentWidth: CGFloat = 0
-
+        
         for viewController in viewControllers {
             let childController = viewController as! IndicatorInfoProvider // swiftlint:disable:this force_cast
             let indicatorInfo = childController.indicatorInfo(for: self)
@@ -372,29 +381,29 @@ open class ButtonBarPagerTabStripViewController: PagerTabStripViewController, Pa
                 collectionViewContentWidth += width
             }
         }
-
+        
         let cellSpacingTotal = CGFloat(numberOfCells - 1) * flowLayout.minimumLineSpacing
         collectionViewContentWidth += cellSpacingTotal
-
+        
         let collectionViewAvailableVisibleWidth = buttonBarView.frame.size.width - flowLayout.sectionInset.left - flowLayout.sectionInset.right
-
+        
         if !settings.style.buttonBarItemsShouldFillAvailableWidth || collectionViewAvailableVisibleWidth < collectionViewContentWidth {
             return minimumCellWidths
         } else {
             let stretchedCellWidthIfAllEqual = (collectionViewAvailableVisibleWidth - cellSpacingTotal) / CGFloat(numberOfCells)
             let generalMinimumCellWidth = calculateStretchedCellWidths(minimumCellWidths, suggestedStretchedCellWidth: stretchedCellWidthIfAllEqual, previousNumberOfLargeCells: 0)
             var stretchedCellWidths = [CGFloat]()
-
+            
             for minimumCellWidthValue in minimumCellWidths {
                 let cellWidth = (minimumCellWidthValue > generalMinimumCellWidth) ? minimumCellWidthValue : generalMinimumCellWidth
                 stretchedCellWidths.append(cellWidth)
             }
-
+            
             return stretchedCellWidths
         }
     }
-
+    
     private var shouldUpdateButtonBarView = true
     private var collectionViewDidLoad = false
-
+    
 }


### PR DESCRIPTION
Since there was no bottomborder Setting in barViews, I added bottomborder settings to "BarPagerTabStripViewController, ButtonBarPagerTabStripViewController" these two files.

"
public var bottomBorderHeight: CGFloat = 0 // bottomBorderHeight
public var bottomBorderColor: UIColor?
"

by modifying these two values you can add bottom border to your tabViews.

(The border is developed with UIView which height is 'bottomBorderHeight')