### PR TITLE
Fix compilation of the project when using Xcode 9 new build system and CocoaPods

### DIFF
--- a/XLPagerTabStrip.podspec
+++ b/XLPagerTabStrip.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.social_media_url = 'https://twitter.com/xmartlabs'
   s.ios.deployment_target = '8.0'
   s.requires_arc = true
-  s.ios.source_files = 'Sources/**/*'
+  s.ios.source_files = 'Sources/**/*.{h,m,swift}'
   s.ios.frameworks = 'UIKit', 'Foundation'
   s.resource_bundles = { 'XLPagerTabStrip' => ['Sources/ButtonCell.xib'] }
 end


### PR DESCRIPTION
With current podspec, one .xib file is getting picked up as a source, and is getting into Xcode Compile Sources build step in CocoaPods generated project. 

New build system is more strict than the old one, and prohibits this by saying:

```
error: unexpected duplicate task: CompileXIB /Path-To-Project/Pods/XLPagerTabStrip/Sources/ButtonCell.xib (in target 'XLPagerTabStrip')
```

This behavior is described in [this CocoaPods issue](https://github.com/CocoaPods/CocoaPods/issues/7079).

This PR changes source_files search path from being * to more specific code-related one *.{h,m,swift}, thus picking only sources into sources.

This fix can be verified by installing XLPagerTabStrip, trying to build with new Build System - it will fail. Then you can remove ButtonCell.xib file from Pods -> XLPagerTabStrip -> Compile Sources build phase and this time project will build successfully.

