### PR TITLE
Accessibility traits + labels

### DIFF
--- a/Sources/BaseButtonBarPagerTabStripViewController.swift
+++ b/Sources/BaseButtonBarPagerTabStripViewController.swift
@@ -131,6 +131,7 @@ open class BaseButtonBarPagerTabStripViewController<ButtonBarCellType: UICollect
         // selectedBar is resized and its contentOffset/scroll is set correctly (the selected
         // tab/cell may end up either skewed or off screen after a rotation otherwise)
         buttonBarView.moveTo(index: currentIndex, animated: false, swipeDirection: .none, pagerScroll: .scrollOnlyIfOutOfScreen)
+        buttonBarView.selectItem(at: IndexPath(item: currentIndex, section: 0), animated: false, scrollPosition: [])
     }
 
     // MARK: - View Rotation
@@ -340,6 +341,7 @@ open class ExampleBaseButtonBarPagerTabStripViewController: BaseButtonBarPagerTa
 
     open override func configure(cell: ButtonBarViewCell, for indicatorInfo: IndicatorInfo) {
         cell.label.text = indicatorInfo.title
+        cell.accessibilityLabel = indicatorInfo.accessibilityLabel
         if let image = indicatorInfo.image {
             cell.imageView.image = image
         }

--- a/Sources/ButtonBarPagerTabStripViewController.swift
+++ b/Sources/ButtonBarPagerTabStripViewController.swift
@@ -194,6 +194,7 @@ open class ButtonBarPagerTabStripViewController: PagerTabStripViewController, Pa
         // selectedBar is resized and its contentOffset/scroll is set correctly (the selected
         // tab/cell may end up either skewed or off screen after a rotation otherwise)
         buttonBarView.moveTo(index: currentIndex, animated: false, swipeDirection: .none, pagerScroll: .scrollOnlyIfOutOfScreen)
+        buttonBarView.selectItem(at: IndexPath(item: currentIndex, section: 0), animated: false, scrollPosition: [])
     }
 
     // MARK: - Public Methods
@@ -323,6 +324,7 @@ open class ButtonBarPagerTabStripViewController: PagerTabStripViewController, Pa
         let indicatorInfo = childController.indicatorInfo(for: self)
 
         cell.label.text = indicatorInfo.title
+        cell.accessibilityLabel = indicatorInfo.accessibilityLabel
         cell.label.font = settings.style.buttonBarItemFont
         cell.label.textColor = settings.style.buttonBarItemTitleColor ?? cell.label.textColor
         cell.contentView.backgroundColor = settings.style.buttonBarItemBackgroundColor ?? cell.contentView.backgroundColor

--- a/Sources/ButtonBarViewCell.swift
+++ b/Sources/ButtonBarViewCell.swift
@@ -29,4 +29,25 @@ open class ButtonBarViewCell: UICollectionViewCell {
     @IBOutlet open var imageView: UIImageView!
     @IBOutlet open var label: UILabel!
 
+    public required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        
+        isAccessibilityElement = true
+        accessibilityTraits |= UIAccessibilityTraitButton
+        accessibilityTraits |= UIAccessibilityTraitHeader
+    }
+    
+    open override var isSelected: Bool {
+        get {
+            return super.isSelected
+        }
+        set {
+            super.isSelected = newValue
+            if (newValue) {
+                accessibilityTraits |= UIAccessibilityTraitSelected
+            } else {
+                accessibilityTraits &= ~UIAccessibilityTraitSelected
+            }
+        }
+    }
 }

--- a/Sources/IndicatorInfo.swift
+++ b/Sources/IndicatorInfo.swift
@@ -29,21 +29,34 @@ public struct IndicatorInfo {
     public var title: String?
     public var image: UIImage?
     public var highlightedImage: UIImage?
+    public var accessibilityLabel: String?
     public var userInfo: Any?
     
     public init(title: String?) {
         self.title = title
+        self.accessibilityLabel = title
     }
     
     public init(image: UIImage?, highlightedImage: UIImage? = nil, userInfo: Any? = nil) {
         self.image = image
         self.highlightedImage = highlightedImage
+        self.userInfo = userInfo
     }
     
     public init(title: String?, image: UIImage?, highlightedImage: UIImage? = nil, userInfo: Any? = nil) {
         self.title = title
+        self.accessibilityLabel = title
         self.image = image
         self.highlightedImage = highlightedImage
+        self.userInfo = userInfo
+    }
+    
+    public init(title: String?, accessibilityLabel:String?, image: UIImage?, highlightedImage: UIImage? = nil, userInfo: Any? = nil) {
+        self.title = title
+        self.accessibilityLabel = accessibilityLabel
+        self.image = image
+        self.highlightedImage = highlightedImage
+        self.userInfo = userInfo
     }
 
 }
@@ -52,13 +65,16 @@ extension IndicatorInfo : ExpressibleByStringLiteral {
 
     public init(stringLiteral value: String) {
         title = value
+        accessibilityLabel = value
     }
 
     public init(extendedGraphemeClusterLiteral value: String) {
         title = value
+        accessibilityLabel = value
     }
 
     public init(unicodeScalarLiteral value: String) {
         title = value
+        accessibilityLabel = value
     }
 }


### PR DESCRIPTION
There are two open pull requests that never made it into master:

- https://github.com/xmartlabs/XLPagerTabStrip/pull/323
- https://github.com/xmartlabs/XLPagerTabStrip/pull/410

I improved on the work that has been done there by making the accessibility traits work for all components/configurations included in the framework. Additionally I added the label as a property to IndicatorInfo, so that users can set accessibility labels when they are using only icons. If they are not specifying a an accessibility label, it will default to the title. 