### PR TITLE
fix: segmentControl reference error

### DIFF
--- a/Sources/SegmentedPagerTabStripViewController.swift
+++ b/Sources/SegmentedPagerTabStripViewController.swift
@@ -35,7 +35,7 @@ public struct SegmentedPagerTabStripSettings {
 
 open class SegmentedPagerTabStripViewController: PagerTabStripViewController, PagerTabStripDataSource, PagerTabStripDelegate {
 
-    @IBOutlet weak public var segmentedControl: UISegmentedControl!
+    @IBOutlet public var segmentedControl: UISegmentedControl!
 
     open var settings = SegmentedPagerTabStripSettings()
 


### PR DESCRIPTION
`if segmentedControl.superview == nil { ... }` this line of code in `viewDidLoad` will crash, if segmentControl is nil when `viewDidLoad` was called.

In the previous line, tough we provide a default value `UISegmentedControl()` for `segmentControl`, but because `segmentControl` was declared as `weak`, we don't have any strong reference refer to the default value, it will release immediately.

I think the best way to solve it is remove the `weak` declaration.

