### PR TITLE
Removing deprecated flatMap

### DIFF
--- a/Sources/ButtonBarPagerTabStripViewController.swift
+++ b/Sources/ButtonBarPagerTabStripViewController.swift
@@ -259,11 +259,11 @@ open class ButtonBarPagerTabStripViewController: PagerTabStripViewController, Pa
 
         if reload {
             let indexPathsToReload = cells.enumerated()
-                .flatMap { (arg) -> IndexPath? in
+                .compactMap { (arg) -> IndexPath? in
                     let (index, cell) = arg
                     return cell == nil ? indexPaths[index] : nil
                 }
-                .flatMap { (indexPath: IndexPath) -> IndexPath? in
+                .compactMap { (indexPath: IndexPath) -> IndexPath? in
                     return (indexPath.item >= 0 && indexPath.item < buttonBarView.numberOfItems(inSection: indexPath.section)) ? indexPath : nil
                 }
 


### PR DESCRIPTION
## Motivation
Xcode 9.3 introduced a new method for when closures return an optional value, thus, it generated warnings on the project

## Changes
- Change `flatMap` to `compactMap`