### PR TITLE
Fix SIGSEGV crash on reloading cells of ButtonBarView

### DIFF
--- a/Sources/ButtonBarPagerTabStripViewController.swift
+++ b/Sources/ButtonBarPagerTabStripViewController.swift
@@ -258,7 +258,7 @@ open class ButtonBarPagerTabStripViewController: PagerTabStripViewController, Pa
         let cells = indexPaths.map { buttonBarView.cellForItem(at: $0) as? ButtonBarViewCell }
 
         if reload {
-            let indexPathsToReload = cells.enumerated()
+            var indexPathsToReload = cells.enumerated()
                 .compactMap { (arg) -> IndexPath? in
                     let (index, cell) = arg
                     return cell == nil ? indexPaths[index] : nil
@@ -268,6 +268,7 @@ open class ButtonBarPagerTabStripViewController: PagerTabStripViewController, Pa
                 }
 
             if !indexPathsToReload.isEmpty {
+                indexPathsToReload = Array(Set(indexPathsToReload))
                 buttonBarView.reloadItems(at: indexPathsToReload)
             }
         }


### PR DESCRIPTION
Fix SIGSEGV crash happening when passing duplicated indexPaths to `reloadItems` method. 

Please release a new version with this fix, we're having issues in production related with this. Thanks!