### PR TITLE
Fixed the ButtonBarView animation when scrolling back to the first and the last element

### DIFF
--- a/Sources/BarView.swift
+++ b/Sources/BarView.swift
@@ -1,4 +1,4 @@
-//  BarView.swift
+//  ButtonBarView.swift
 //  XLPagerTabStrip ( https://github.com/xmartlabs/XLPagerTabStrip )
 //
 //  Copyright (c) 2017 Xmartlabs ( http://xmartlabs.com )
@@ -22,22 +22,42 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
+import UIKit
 
-open class BarView: UIView {
+public enum PagerScroll {
+    case no
+    case yes
+    case scrollOnlyIfOutOfScreen
+}
+
+public enum SelectedBarAlignment {
+    case left
+    case center
+    case right
+    case progressive
+}
+
+public enum SelectedBarVerticalAlignment {
+    case top
+    case middle
+    case bottom
+}
+
+open class ButtonBarView: UICollectionView {
 
     open lazy var selectedBar: UIView = { [unowned self] in
-        let selectedBar = UIView(frame: CGRect(x: 0, y: 0, width: self.frame.size.width, height: self.frame.size.height))
-        return selectedBar
+        let bar  = UIView(frame: CGRect(x: 0, y: self.frame.size.height - CGFloat(self.selectedBarHeight), width: 0, height: CGFloat(self.selectedBarHeight)))
+        bar.layer.zPosition = 9999
+        return bar
     }()
 
-    var optionsCount = 1 {
-        willSet(newOptionsCount) {
-            if newOptionsCount <= selectedIndex {
-                selectedIndex = optionsCount - 1
-            }
+    internal var selectedBarHeight: CGFloat = 4 {
+        didSet {
+            updateSelectedBarYPosition()
         }
     }
+    var selectedBarVerticalAlignment: SelectedBarVerticalAlignment = .bottom
+    var selectedBarAlignment: SelectedBarAlignment = .center
     var selectedIndex = 0
 
     required public init?(coder aDecoder: NSCoder) {
@@ -45,47 +65,146 @@ open class BarView: UIView {
         addSubview(selectedBar)
     }
 
-    override init(frame: CGRect) {
-        super.init(frame: frame)
+    public override init(frame: CGRect, collectionViewLayout layout: UICollectionViewLayout) {
+        super.init(frame: frame, collectionViewLayout: layout)
         addSubview(selectedBar)
+    }
+
+    open func moveTo(index: Int, animated: Bool, swipeDirection: SwipeDirection, pagerScroll: PagerScroll) {
+        selectedIndex = index
+        updateSelectedBarPosition(animated, swipeDirection: swipeDirection, pagerScroll: pagerScroll)
+    }
+
+    open func move(fromIndex: Int, toIndex: Int, progressPercentage: CGFloat, pagerScroll: PagerScroll) {
+
+        selectedIndex = progressPercentage > 0.5 ? toIndex : fromIndex
+
+        let numberOfItems = dataSource!.collectionView(self, numberOfItemsInSection: 0)
+        var progressPercentage = progressPercentage
+        
+        
+        var fromFrame: CGRect
+        
+        if fromIndex < 0 || fromIndex > numberOfItems - 1 {
+            if fromIndex < 0 {
+                let cellAtts = layoutAttributesForItem(at: IndexPath(item: 0, section: 0))
+                fromFrame = cellAtts!.frame.offsetBy(dx: -cellAtts!.frame.size.width, dy: 0)
+                progressPercentage = 1 - progressPercentage * -1
+            } else {
+                let cellAtts = layoutAttributesForItem(at: IndexPath(item: (numberOfItems - 1), section: 0))
+                fromFrame = cellAtts!.frame.offsetBy(dx: cellAtts!.frame.size.width, dy: 0)
+            }
+        } else {
+            fromFrame = layoutAttributesForItem(at: IndexPath(item: fromIndex, section: 0))!.frame
+        }
+        
+
+        var toFrame: CGRect
+
+        if toIndex < 0 || toIndex > numberOfItems - 1 {
+            if toIndex < 0 {
+                let cellAtts = layoutAttributesForItem(at: IndexPath(item: 0, section: 0))
+                toFrame = cellAtts!.frame.offsetBy(dx: -cellAtts!.frame.size.width, dy: 0)
+            } else {
+                let cellAtts = layoutAttributesForItem(at: IndexPath(item: (numberOfItems - 1), section: 0))
+                toFrame = cellAtts!.frame.offsetBy(dx: cellAtts!.frame.size.width, dy: 0)
+            }
+        } else {
+            toFrame = layoutAttributesForItem(at: IndexPath(item: toIndex, section: 0))!.frame
+        }
+
+        
+        var targetFrame = fromFrame
+        targetFrame.size.height = selectedBar.frame.size.height
+        targetFrame.size.width += (toFrame.size.width - fromFrame.size.width) * progressPercentage
+        targetFrame.origin.x += (toFrame.origin.x - fromFrame.origin.x) * progressPercentage
+        
+        selectedBar.frame = CGRect(x: targetFrame.origin.x, y: selectedBar.frame.origin.y, width: targetFrame.size.width, height: selectedBar.frame.size.height)
+
+        var targetContentOffset: CGFloat = 0.0
+        if contentSize.width > frame.size.width {
+            let toContentOffset = contentOffsetForCell(withFrame: toFrame, andIndex: toIndex)
+            let fromContentOffset = contentOffsetForCell(withFrame: fromFrame, andIndex: fromIndex)
+
+            targetContentOffset = fromContentOffset + ((toContentOffset - fromContentOffset) * progressPercentage)
+        }
+
+        setContentOffset(CGPoint(x: targetContentOffset, y: 0), animated: false)
+    }
+
+    open func updateSelectedBarPosition(_ animated: Bool, swipeDirection: SwipeDirection, pagerScroll: PagerScroll) {
+        var selectedBarFrame = selectedBar.frame
+
+        let selectedCellIndexPath = IndexPath(item: selectedIndex, section: 0)
+        let attributes = layoutAttributesForItem(at: selectedCellIndexPath)
+        let selectedCellFrame = attributes!.frame
+
+        updateContentOffset(animated: animated, pagerScroll: pagerScroll, toFrame: selectedCellFrame, toIndex: (selectedCellIndexPath as NSIndexPath).row)
+
+        selectedBarFrame.size.width = selectedCellFrame.size.width
+        selectedBarFrame.origin.x = selectedCellFrame.origin.x
+
+        if animated {
+            UIView.animate(withDuration: 0.3, animations: { [weak self] in
+                self?.selectedBar.frame = selectedBarFrame
+            })
+        } else {
+            selectedBar.frame = selectedBarFrame
+        }
     }
 
     // MARK: - Helpers
 
-    private func updateSelectedBarPosition(with animation: Bool) {
-        var frame = selectedBar.frame
-        frame.size.width = self.frame.size.width / CGFloat(optionsCount)
-        frame.origin.x = frame.size.width * CGFloat(selectedIndex)
-        if animation {
-            UIView.animate(withDuration: 0.3, animations: { [weak self] in
-                self?.selectedBar.frame = frame
-            })
-        } else {
-            selectedBar.frame = frame
+    private func updateContentOffset(animated: Bool, pagerScroll: PagerScroll, toFrame: CGRect, toIndex: Int) {
+        guard pagerScroll != .no || (pagerScroll != .scrollOnlyIfOutOfScreen && (toFrame.origin.x < contentOffset.x || toFrame.origin.x >= (contentOffset.x + frame.size.width - contentInset.left))) else { return }
+        let targetContentOffset = contentSize.width > frame.size.width ? contentOffsetForCell(withFrame: toFrame, andIndex: toIndex) : 0
+        setContentOffset(CGPoint(x: targetContentOffset, y: 0), animated: animated)
+    }
+
+    private func contentOffsetForCell(withFrame cellFrame: CGRect, andIndex index: Int) -> CGFloat {
+        let sectionInset = (collectionViewLayout as! UICollectionViewFlowLayout).sectionInset // swiftlint:disable:this force_cast
+        var alignmentOffset: CGFloat = 0.0
+
+        switch selectedBarAlignment {
+        case .left:
+            alignmentOffset = sectionInset.left
+        case .right:
+            alignmentOffset = frame.size.width - sectionInset.right - cellFrame.size.width
+        case .center:
+            alignmentOffset = (frame.size.width - cellFrame.size.width) * 0.5
+        case .progressive:
+            let cellHalfWidth = cellFrame.size.width * 0.5
+            let leftAlignmentOffset = sectionInset.left + cellHalfWidth
+            let rightAlignmentOffset = frame.size.width - sectionInset.right - cellHalfWidth
+            let numberOfItems = dataSource!.collectionView(self, numberOfItemsInSection: 0)
+            let progress = index / (numberOfItems - 1)
+            alignmentOffset = leftAlignmentOffset + (rightAlignmentOffset - leftAlignmentOffset) * CGFloat(progress) - cellHalfWidth
         }
+
+        var contentOffset = cellFrame.origin.x - alignmentOffset
+        contentOffset = max(0, contentOffset)
+        contentOffset = min(contentSize.width - frame.size.width, contentOffset)
+        return contentOffset
     }
 
-    open func moveTo(index: Int, animated: Bool) {
-        selectedIndex = index
-        updateSelectedBarPosition(with: animated)
+    private func updateSelectedBarYPosition() {
+        var selectedBarFrame = selectedBar.frame
+
+        switch selectedBarVerticalAlignment {
+        case .top:
+            selectedBarFrame.origin.y = 0
+        case .middle:
+            selectedBarFrame.origin.y = (frame.size.height - selectedBarHeight) / 2
+        case .bottom:
+            selectedBarFrame.origin.y = frame.size.height - selectedBarHeight
+        }
+
+        selectedBarFrame.size.height = selectedBarHeight
+        selectedBar.frame = selectedBarFrame
     }
 
-    open func move(fromIndex: Int, toIndex: Int, progressPercentage: CGFloat) {
-        selectedIndex = (progressPercentage > 0.5) ? toIndex : fromIndex
-
-        var newFrame = selectedBar.frame
-        newFrame.size.width = frame.size.width / CGFloat(optionsCount)
-        var fromFrame = newFrame
-        fromFrame.origin.x = newFrame.size.width * CGFloat(fromIndex)
-        var toFrame = newFrame
-        toFrame.origin.x = toFrame.size.width * CGFloat(toIndex)
-        var targetFrame = fromFrame
-        targetFrame.origin.x += (toFrame.origin.x - targetFrame.origin.x) * CGFloat(progressPercentage)
-        selectedBar.frame = targetFrame
-    }
-
-    open override func layoutSubviews() {
+    override open func layoutSubviews() {
         super.layoutSubviews()
-        updateSelectedBarPosition(with: false)
+        updateSelectedBarYPosition()
     }
 }

--- a/Sources/ButtonBarView.swift
+++ b/Sources/ButtonBarView.swift
@@ -76,10 +76,28 @@ open class ButtonBarView: UICollectionView {
     }
 
     open func move(fromIndex: Int, toIndex: Int, progressPercentage: CGFloat, pagerScroll: PagerScroll) {
+
         selectedIndex = progressPercentage > 0.5 ? toIndex : fromIndex
 
-        let fromFrame = layoutAttributesForItem(at: IndexPath(item: fromIndex, section: 0))!.frame
         let numberOfItems = dataSource!.collectionView(self, numberOfItemsInSection: 0)
+        var progressPercentage = progressPercentage
+        
+        
+        var fromFrame: CGRect
+        
+        if fromIndex < 0 || fromIndex > numberOfItems - 1 {
+            if fromIndex < 0 {
+                let cellAtts = layoutAttributesForItem(at: IndexPath(item: 0, section: 0))
+                fromFrame = cellAtts!.frame.offsetBy(dx: -cellAtts!.frame.size.width, dy: 0)
+                progressPercentage = 1 - progressPercentage * -1
+            } else {
+                let cellAtts = layoutAttributesForItem(at: IndexPath(item: (numberOfItems - 1), section: 0))
+                fromFrame = cellAtts!.frame.offsetBy(dx: cellAtts!.frame.size.width, dy: 0)
+            }
+        } else {
+            fromFrame = layoutAttributesForItem(at: IndexPath(item: fromIndex, section: 0))!.frame
+        }
+        
 
         var toFrame: CGRect
 
@@ -95,11 +113,12 @@ open class ButtonBarView: UICollectionView {
             toFrame = layoutAttributesForItem(at: IndexPath(item: toIndex, section: 0))!.frame
         }
 
+        
         var targetFrame = fromFrame
         targetFrame.size.height = selectedBar.frame.size.height
         targetFrame.size.width += (toFrame.size.width - fromFrame.size.width) * progressPercentage
         targetFrame.origin.x += (toFrame.origin.x - fromFrame.origin.x) * progressPercentage
-
+        
         selectedBar.frame = CGRect(x: targetFrame.origin.x, y: selectedBar.frame.origin.y, width: targetFrame.size.width, height: selectedBar.frame.size.height)
 
         var targetContentOffset: CGFloat = 0.0

--- a/Sources/ButtonCell.xib
+++ b/Sources/ButtonCell.xib
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="12120" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="zg4-fX-zUF" customClass="ButtonBarViewCell" customModule="XLPagerTabStrip" customModuleProvider="target">
+        <collectionViewCell opaque="NO" multipleTouchEnabled="YES" contentMode="center" id="zg4-fX-zUF" customClass="ButtonBarViewCell" customModule="XLPagerTabStrip" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="80" height="40"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">

--- a/Sources/PagerTabStripViewController.swift
+++ b/Sources/PagerTabStripViewController.swift
@@ -299,7 +299,7 @@ open class PagerTabStripViewController: UIViewController, UIScrollViewDelegate {
         updateContent()
     }
 
-    // MARK: - UIScrollViewDelegate
+    // MARK: - UIScrollDelegate
 
     open func scrollViewDidScroll(_ scrollView: UIScrollView) {
         if containerView == scrollView {
@@ -350,14 +350,21 @@ open class PagerTabStripViewController: UIViewController, UIScrollViewDelegate {
                 fromIndex = count - 1
                 toIndex = count
             } else {
-                if self.scrollPercentage >= 0.5 {
+                if self.scrollPercentage <= 0 {
+                    toIndex = currentIndex
+                    fromIndex = currentIndex - 1
+                }
+                else if self.scrollPercentage >= 0.5 {
                     fromIndex = max(toIndex - 1, 0)
                 } else {
                     toIndex = fromIndex + 1
                 }
             }
         } else if direction == .right {
-            if virtualPage < 0 {
+            if virtualPage >= count - 1 && self.scrollPercentage > 0.5 {
+                fromIndex = count
+                toIndex = count - 1
+            } else if virtualPage < 0 {
                 fromIndex = 0
                 toIndex = -1
             } else {


### PR DESCRIPTION
There was a visible jolt in ButtonBar animation when you drag the pager to the left or right from respectively the left- and rightmost elements and then release. Fixed that.
Please review this commits and maybe replicate them by yourself, because I've just edited a bunch of files right in GitHub and one of them by mistake. Sorry for that.