### PR TITLE
[Example] Update PostCell to use contentView

### DIFF
--- a/Example/Example/Base.lproj/Storyboard.storyboard
+++ b/Example/Example/Base.lproj/Storyboard.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="SCa-L8-uTr">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="SCa-L8-uTr">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13527"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="Navigation items with more than one left or right bar item" minToolsVersion="7.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -40,7 +40,7 @@
                     <navigationItem key="navigationItem" id="l1f-vB-6A8">
                         <nil key="title"/>
                         <segmentedControl key="titleView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="bar" selectedSegmentIndex="0" id="31B-gy-WIH">
-                            <rect key="frame" x="26" y="7" width="304" height="30"/>
+                            <rect key="frame" x="20" y="7" width="304" height="30"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <segments>
                                 <segment title="First"/>
@@ -460,6 +460,7 @@
                     </tabBarItem>
                     <toolbarItems/>
                     <navigationBar key="navigationBar" opaque="NO" contentMode="scaleToFill" translucent="NO" id="TRx-vY-PeE">
+                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="barTintColor" red="0.027450980390000001" green="0.72549019609999998" blue="0.60784313729999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </navigationBar>
@@ -481,6 +482,7 @@
                     </tabBarItem>
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="2I8-g6-D4S">
+                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="barTintColor" red="0.027450980390000001" green="0.72549019609999998" blue="0.60784313729999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <textAttributes key="titleTextAttributes">
@@ -600,6 +602,7 @@
                     </tabBarItem>
                     <toolbarItems/>
                     <navigationBar key="navigationBar" opaque="NO" contentMode="scaleToFill" translucent="NO" id="iMm-hr-oOU">
+                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="barTintColor" red="0.027450980390000001" green="0.72549019609999998" blue="0.60784313729999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </navigationBar>
@@ -621,6 +624,7 @@
                     </tabBarItem>
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="PUj-LI-AQ6">
+                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="barTintColor" red="0.027450980390000001" green="0.72549019609999998" blue="0.60784313729999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <textAttributes key="titleTextAttributes">

--- a/Example/Example/Helpers/PostCell.xib
+++ b/Example/Example/Helpers/PostCell.xib
@@ -1,57 +1,62 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="PostCell" customModule="Example" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="326" height="84"/>
-            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-            <subviews>
-                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="3cF-Pb-bhF">
-                    <rect key="frame" x="12" y="12" width="60" height="60"/>
-                    <constraints>
-                        <constraint firstAttribute="width" constant="60" id="Pny-Yy-5g4"/>
-                        <constraint firstAttribute="height" constant="60" id="xre-y3-QCa"/>
-                    </constraints>
-                </imageView>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XpS-ev-AZK">
-                    <rect key="frame" x="80" y="12" width="229" height="18"/>
-                    <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
-                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
-                    <nil key="highlightedColor"/>
-                </label>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="M84-ZZ-G5B">
-                    <rect key="frame" x="80" y="38" width="229" height="18"/>
-                    <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
-                    <nil key="highlightedColor"/>
-                </label>
-            </subviews>
-            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
-            <constraints>
-                <constraint firstAttribute="trailing" secondItem="M84-ZZ-G5B" secondAttribute="trailing" constant="17" id="ERc-X0-bm6"/>
-                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="M84-ZZ-G5B" secondAttribute="bottom" priority="999" constant="20" id="I1d-nA-bLK"/>
-                <constraint firstItem="XpS-ev-AZK" firstAttribute="leading" secondItem="3cF-Pb-bhF" secondAttribute="trailing" constant="8" id="MCp-qr-s7q"/>
-                <constraint firstItem="M84-ZZ-G5B" firstAttribute="top" secondItem="XpS-ev-AZK" secondAttribute="bottom" constant="8" id="PxD-gM-hbj"/>
-                <constraint firstItem="M84-ZZ-G5B" firstAttribute="leading" secondItem="3cF-Pb-bhF" secondAttribute="trailing" constant="8" id="VmA-J2-6Ur"/>
-                <constraint firstItem="3cF-Pb-bhF" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="12" id="Vqu-xf-y9G"/>
-                <constraint firstItem="XpS-ev-AZK" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="12" id="XP8-3C-YTa"/>
-                <constraint firstAttribute="trailing" secondItem="XpS-ev-AZK" secondAttribute="trailing" constant="17" id="dh0-1d-SBr"/>
-                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="3cF-Pb-bhF" secondAttribute="bottom" priority="999" constant="12" id="f9x-qu-WpO"/>
-                <constraint firstItem="3cF-Pb-bhF" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="12" id="rjQ-uH-Euv"/>
-            </constraints>
-            <nil key="simulatedStatusBarMetrics"/>
-            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="84" id="b8n-8Y-pxb" customClass="PostCell" customModule="Example" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="84"/>
+            <autoresizingMask key="autoresizingMask"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="b8n-8Y-pxb" id="K88-rd-6gZ">
+                <rect key="frame" x="0.0" y="0.0" width="375" height="83.5"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="wQ5-jv-KcD">
+                        <rect key="frame" x="12" y="12" width="60" height="60"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="60" id="a22-Yz-B14"/>
+                            <constraint firstAttribute="width" constant="60" id="h3B-3k-YAV"/>
+                        </constraints>
+                    </imageView>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Xt9-VS-IpY">
+                        <rect key="frame" x="80" y="12" width="278" height="18"/>
+                        <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
+                        <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fIC-u4-GzA">
+                        <rect key="frame" x="80" y="38" width="278" height="18"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                        <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="wQ5-jv-KcD" firstAttribute="top" secondItem="K88-rd-6gZ" secondAttribute="top" constant="12" id="0nA-Ff-0jE"/>
+                    <constraint firstItem="Xt9-VS-IpY" firstAttribute="leading" secondItem="wQ5-jv-KcD" secondAttribute="trailing" constant="8" id="CJD-v3-ZI5"/>
+                    <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="fIC-u4-GzA" secondAttribute="bottom" priority="999" constant="20" id="Dsa-9n-hAy"/>
+                    <constraint firstAttribute="trailing" secondItem="fIC-u4-GzA" secondAttribute="trailing" constant="17" id="NGB-u3-BwT"/>
+                    <constraint firstItem="Xt9-VS-IpY" firstAttribute="top" secondItem="K88-rd-6gZ" secondAttribute="top" constant="12" id="aeT-ml-Joy"/>
+                    <constraint firstItem="fIC-u4-GzA" firstAttribute="leading" secondItem="wQ5-jv-KcD" secondAttribute="trailing" constant="8" id="cdd-j8-SOs"/>
+                    <constraint firstItem="wQ5-jv-KcD" firstAttribute="leading" secondItem="K88-rd-6gZ" secondAttribute="leading" constant="12" id="hyC-j1-1ur"/>
+                    <constraint firstAttribute="bottom" secondItem="wQ5-jv-KcD" secondAttribute="bottom" priority="999" constant="12" id="igs-Iw-meI"/>
+                    <constraint firstAttribute="trailing" secondItem="Xt9-VS-IpY" secondAttribute="trailing" constant="17" id="xNw-iC-WEv"/>
+                    <constraint firstItem="fIC-u4-GzA" firstAttribute="top" secondItem="Xt9-VS-IpY" secondAttribute="bottom" constant="8" id="ypP-AG-hch"/>
+                </constraints>
+            </tableViewCellContentView>
             <connections>
-                <outlet property="postName" destination="XpS-ev-AZK" id="sua-hr-KD7"/>
-                <outlet property="postText" destination="M84-ZZ-G5B" id="981-BE-BOc"/>
-                <outlet property="userImage" destination="3cF-Pb-bhF" id="rkH-iK-qN8"/>
+                <outlet property="postName" destination="Xt9-VS-IpY" id="VYd-5D-WAS"/>
+                <outlet property="postText" destination="fIC-u4-GzA" id="GvN-fW-jWH"/>
+                <outlet property="userImage" destination="wQ5-jv-KcD" id="T64-Nd-dc9"/>
             </connections>
-            <point key="canvasLocation" x="362" y="495"/>
-        </view>
+            <point key="canvasLocation" x="348" y="692"/>
+        </tableViewCell>
     </objects>
 </document>


### PR DESCRIPTION
We need to place subviews onto UITableViewCell's contentView (to use `UITableViewCell.insetsContentViewsToSafeArea`: https://developer.apple.com/documentation/uikit/uitableview/2921665-insetscontentviewstosafearea).

Fixes https://github.com/xmartlabs/XLPagerTabStrip/issues/498 (https://github.com/xmartlabs/XLPagerTabStrip/issues/498#issuecomment-418579377).

Before:
<img width="233" alt="2018-09-05 11 44 35" src="https://user-images.githubusercontent.com/909674/45068150-1928fb80-b101-11e8-97c9-009cc4937224.png">

After:
<img width="237" alt="2018-09-05 11 42 31" src="https://user-images.githubusercontent.com/909674/45068114-f860a600-b100-11e8-972c-db42aeaddff7.png">