### PR TITLE
Add a flag where the user can handle the resizing of the view in a SplitViewController

### DIFF
--- a/Sources/ButtonBarPagerTabStripViewController.swift
+++ b/Sources/ButtonBarPagerTabStripViewController.swift
@@ -176,7 +176,7 @@ open class ButtonBarPagerTabStripViewController: PagerTabStripViewController, Pa
     open override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
 
-        guard isViewAppearing || isViewRotating else { return }
+        guard isViewAppearing || isViewRotating || isViewResizing else { return }
 
         // Force the UICollectionViewFlowLayout to get laid out again with the new size if
         // a) The view is appearing.  This ensures that
@@ -188,6 +188,10 @@ open class ButtonBarPagerTabStripViewController: PagerTabStripViewController, Pa
         // b) The view is rotating.  This ensures that
         //    collectionView:layout:sizeForItemAtIndexPath: is called again and can use the views
         //    *new* frame so that the buttonBarView cell's actually get resized correctly
+        // c) In case the view controller is encapsulated inside a split view controller
+        // make sure to set isViewResizing to true in the split controller's delegate method
+        // splitViewController(_ svc: UISplitViewController, willChangeTo displayMode: UISplitViewController.DisplayMode)
+        isViewResizing = false
         cachedCellWidths = calculateWidths()
         buttonBarView.collectionViewLayout.invalidateLayout()
         // When the view first appears or is rotated we also need to ensure that the barButtonView's

--- a/Sources/PagerTabStripViewController.swift
+++ b/Sources/PagerTabStripViewController.swift
@@ -392,5 +392,5 @@ open class PagerTabStripViewController: UIViewController, UIScrollViewDelegate {
     private var lastSize = CGSize(width: 0, height: 0)
     internal var isViewRotating = false
     internal var isViewAppearing = false
-
+    open var isViewResizing = false
 }


### PR DESCRIPTION
![simulator screen shot - iphone 8 plus - 2018-10-20 at 12 45 44](https://user-images.githubusercontent.com/9082720/47259196-6b05c500-d4a6-11e8-9ecb-1fc987b8944e.png)

Using the leftItem in the navigation bar of the detailsViewController, the user can expand and collapse the masterViewController which change the size of the detailsViewController, which in case it's a PageViewController does not resize the tabs and there's no clean way of handling this now.

After merging this PR, users will be able to set the flag to true when the delegate method of the splitViewController informs that a change in the displayMode is about to happen.