### PR TITLE
Set selectedBarVerticalAlignment

### DIFF
--- a/Sources/BaseButtonBarPagerTabStripViewController.swift
+++ b/Sources/BaseButtonBarPagerTabStripViewController.swift
@@ -87,7 +87,7 @@ open class BaseButtonBarPagerTabStripViewController<ButtonBarCellType: UICollect
         buttonBarView.showsHorizontalScrollIndicator = false
         buttonBarView.backgroundColor = settings.style.buttonBarBackgroundColor ?? buttonBarView.backgroundColor
         buttonBarView.selectedBar.backgroundColor = settings.style.selectedBarBackgroundColor
-
+        buttonBarView.selectedBarVerticalAlignment = settings.style.selectedBarVerticalAlignment
         buttonBarView.selectedBarHeight = settings.style.selectedBarHeight
         // register button bar item cell
         switch buttonBarItemSpec! {


### PR DESCRIPTION
As mentioned in https://github.com/xmartlabs/XLPagerTabStrip/issues/549

BaseButtonBarPagerTabStripViewController.buttonBarView.selectedBarVerticalAlignment did not respect the settings in the style.

This meant that any subclasses of BaseButtonBarPagerTabStripViewController could not change the vertical alignment of the selected bar.

