### PR TITLE
Show the PagerTabStripViewController with the selected sub-controller (default tab)

### DIFF
--- a/Sources/PagerTabStripViewController.swift
+++ b/Sources/PagerTabStripViewController.swift
@@ -104,7 +104,7 @@ open class PagerTabStripViewController: UIViewController, UIScrollViewDelegate {
         containerView.isPagingEnabled = true
         reloadViewControllers()
 
-		currentIndex = preCurrentIndex
+        currentIndex = preCurrentIndex
         let childController = viewControllers[currentIndex]
         addChild(childController)
         childController.view.autoresizingMask = [.flexibleHeight, .flexibleWidth]

--- a/Sources/PagerTabStripViewController.swift
+++ b/Sources/PagerTabStripViewController.swift
@@ -104,6 +104,7 @@ open class PagerTabStripViewController: UIViewController, UIScrollViewDelegate {
         containerView.isPagingEnabled = true
         reloadViewControllers()
 
+		currentIndex = preCurrentIndex
         let childController = viewControllers[currentIndex]
         addChild(childController)
         childController.view.autoresizingMask = [.flexibleHeight, .flexibleWidth]


### PR DESCRIPTION
Solves the [issue](https://github.com/xmartlabs/XLPagerTabStrip/issues/537)
