### PR TITLE
Add support for SwiftPM based dependency managers

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,8 @@ let package = Package(
     targets: [
         .target(
             name: "XLPagerTabStrip",
-            path: "Sources"
+            path: "Sources",
+            sources: ["Sources/PagerTabStripViewController.swift"]
         )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version:4.2
+import PackageDescription
+
+let package = Package(
+    name: "XLPagerTabStrip",
+    // platforms: [.iOS("9.3")],
+    products: [
+        .library(name: "XLPagerTabStrip", targets: ["XLPagerTabStrip"])
+    ],
+    targets: [
+        .target(
+            name: "XLPagerTabStrip",
+            path: "Sources"
+        )
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
         .target(
             name: "XLPagerTabStrip",
             path: "Sources",
-            sources: ["Sources/PagerTabStripViewController.swift"]
+            exclude: ["FXPageControl.h", "FXPageControl.m"]
         )
     ]
 )

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 <img src="https://img.shields.io/badge/platform-iOS-blue.svg?style=flat" alt="Platform iOS" />
 <a href="https://developer.apple.com/swift"><img src="https://img.shields.io/badge/swift4-compatible-4BC51D.svg?style=flat" alt="Swift 4 compatible" /></a>
 <a href="https://github.com/Carthage/Carthage"><img src="https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat" alt="Carthage compatible" /></a>
+<a href="https://github.com/JamitLabs/Accio"><img src="https://img.shields.io/badge/Accio-supported-0A7CF5.svg?style=flat" alt="Accio supported" /></a>
 <a href="https://cocoapods.org/pods/XLPagerTabStrip"><img src="https://img.shields.io/cocoapods/v/XLPagerTabStrip.svg" alt="CocoaPods compatible" /></a>
 <a href="https://raw.githubusercontent.com/xmartlabs/XLPagerTabStrip/master/LICENSE"><img src="http://img.shields.io/badge/license-MIT-blue.svg?style=flat" alt="License: MIT" />
 </a>
@@ -317,6 +318,29 @@ To install XLPagerTabStrip, simply add the following line to your Cartfile:
 ```ogdl
 github "xmartlabs/XLPagerTabStrip" ~> 8.1
 ```
+
+### Accio
+
+[Accio](https://github.com/JamitLabs/Accio) is a SwiftPM based dependency manager with improvements over Carthage.
+
+To install XLPagerTabStrip, simply add the following to your Package.swift:
+
+```swift
+.package(url: "https://github.com/xmartlabs/XLPagerTabStrip.git", .upToNextMajor(from: "9.0.0")),
+```
+
+Next, add `XLPagerTabStrip` to your App targets dependencies like so:
+
+```swift
+.target(
+    name: "App",
+    dependencies: [
+        "XLPagerTabStrip",
+    ]
+),
+```
+
+Then run `accio update`.
 
 ## FAQ
 


### PR DESCRIPTION
This adds support for SwiftPM manifest based dependency managers. Specifically this adds support for installing via [Accio](https://github.com/JamitLabs/Accio) but will probably also work with SwiftPM once it's integrated into Xcode.

Please note that this project is part of Accio's official [integration tests](https://github.com/JamitLabs/Accio/tree/work/1000-frameworks/Demo/Shared/AppDependencies) within the [Demo project](https://github.com/JamitLabs/Accio/tree/work/1000-frameworks/Demo).