### PR TITLE
Update PagerTabStripViewController.swift

### DIFF
--- a/Sources/PagerTabStripViewController.swift
+++ b/Sources/PagerTabStripViewController.swift
@@ -147,6 +147,21 @@ open class PagerTabStripViewController: UIViewController, UIScrollViewDelegate {
     open override var shouldAutomaticallyForwardAppearanceMethods: Bool {
         return false
     }
+    
+    open func setupDefaultViewController(at index: Int) {
+        guard currentIndex != index else { return }
+        guard isViewLoaded, !self.viewControllers.isEmpty else {
+            currentIndex = index
+            return
+        }
+        guard view.window != nil else {
+        let step = (currentIndex < index) ? 1 : -1
+            for subindex in stride(from: currentIndex+step, through: index, by: step) {
+                containerView.setContentOffset(CGPoint(x: pageOffsetForChild(at: subindex), y: 0), animated: false)
+            }
+            return
+        }
+    }
 
     open func moveToViewController(at index: Int, animated: Bool = true) {
         guard isViewLoaded && view.window != nil && currentIndex != index else {


### PR DESCRIPTION
@xmartlabs
Updated the PL from here: https://github.com/Sepicat/XLPagerTabStrip/commit/81f3b87c884765444a404b2f22afd1bdd11df8f0

I tested this in the latest version of swift 5 for setting up the initial view controller.
everything is working great. no need to Dispatch.main.queue after viewDidLoad.


please merge this to close related issues:
https://github.com/xmartlabs/XLPagerTabStrip/issues/537
https://github.com/xmartlabs/XLPagerTabStrip/issues/553
& this similar PL:
https://github.com/xmartlabs/XLPagerTabStrip/pull/692

