### PR TITLE
Fix for scrollview not respecting the safeArea insets

### DIFF
--- a/Sources/PagerTabStripViewController.swift
+++ b/Sources/PagerTabStripViewController.swift
@@ -237,17 +237,20 @@ open class PagerTabStripViewController: UIViewController, UIScrollViewDelegate {
 
         let pagerViewControllers = pagerTabStripChildViewControllersForScrolling ?? viewControllers
         containerView.contentSize = CGSize(width: containerView.bounds.width * CGFloat(pagerViewControllers.count), height: containerView.contentSize.height)
-
+        var bottom = CGFloat(0)
+        if #available(iOS 11.0, *) {
+            bottom = view.safeAreaInsets.bottom
+        }
         for (index, childController) in pagerViewControllers.enumerated() {
             let pageOffsetForChild = self.pageOffsetForChild(at: index)
             if abs(containerView.contentOffset.x - pageOffsetForChild) < containerView.bounds.width {
                 if childController.parent != nil {
-                    childController.view.frame = CGRect(x: offsetForChild(at: index), y: 0, width: view.bounds.width, height: containerView.bounds.height)
+                    childController.view.frame = CGRect(x: offsetForChild(at: index), y: 0, width: view.bounds.width, height: containerView.bounds.height - bottom)
                     childController.view.autoresizingMask = [.flexibleHeight, .flexibleWidth]
                 } else {
                     childController.beginAppearanceTransition(true, animated: false)
                     addChild(childController)
-                    childController.view.frame = CGRect(x: offsetForChild(at: index), y: 0, width: view.bounds.width, height: containerView.bounds.height)
+                    childController.view.frame = CGRect(x: offsetForChild(at: index), y: 0, width: view.bounds.width, height: containerView.bounds.height - bottom)
                     childController.view.autoresizingMask = [.flexibleHeight, .flexibleWidth]
                     containerView.addSubview(childController.view)
                     childController.didMove(toParent: self)
@@ -329,11 +332,11 @@ open class PagerTabStripViewController: UIViewController, UIScrollViewDelegate {
         isViewRotating = true
         pageBeforeRotate = currentIndex
         coordinator.animate(alongsideTransition: nil) { [weak self] _ in
-            guard let me = self else { return }
-            me.isViewRotating = false
-            me.currentIndex = me.pageBeforeRotate
-            me.preCurrentIndex = me.currentIndex
-            me.updateIfNeeded()
+            guard let self = self else { return }
+            self.isViewRotating = false
+            self.currentIndex = self.pageBeforeRotate
+            self.preCurrentIndex = self.currentIndex
+            self.updateIfNeeded()
         }
     }
 


### PR DESCRIPTION
Hey All :))
As reported here #722 and also possible [here](https://github.com/GitHawkApp/GitHawk/issues/2636)
The scrollView was not respecting the safeArea in the iPhone X. 
