### PR TITLE
Adding support to reload ButtonBarView in ButtonBarPagerTabStripViewController.

### DIFF
--- a/Sources/ButtonBarPagerTabStripViewController.swift
+++ b/Sources/ButtonBarPagerTabStripViewController.swift
@@ -194,9 +194,13 @@ open class ButtonBarPagerTabStripViewController: PagerTabStripViewController, Pa
     open override func reloadPagerTabStripView() {
         super.reloadPagerTabStripView()
         guard isViewLoaded else { return }
+        reloadButtonBarView()
+        buttonBarView.moveTo(index: currentIndex, animated: false, swipeDirection: .none, pagerScroll: .yes)
+    }
+
+    open func reloadButtonBarView() {
         buttonBarView.reloadData()
         cachedCellWidths = calculateWidths()
-        buttonBarView.moveTo(index: currentIndex, animated: false, swipeDirection: .none, pagerScroll: .yes)
     }
 
     open func calculateStretchedCellWidths(_ minimumCellWidths: [CGFloat], suggestedStretchedCellWidth: CGFloat, previousNumberOfLargeCells: Int) -> CGFloat {


### PR DESCRIPTION
Adding support to reload `ButtonBarView` in `ButtonBarPagerTabStripViewController`. This allows for update of the child view controller indicator info dynamically.

When `BarPagerTabStripViewController` `IndicatorInfo` is updated after the initial setup the incorrect cached cell widths are still used. 

This issue can be seen here:
https://github.com/xmartlabs/XLPagerTabStrip/issues/412