### PR TITLE
moveToViewController does not change the page if created + not visible + animated = false until it become visible

### DIFF
--- a/Sources/PagerTabStripViewController.swift
+++ b/Sources/PagerTabStripViewController.swift
@@ -149,7 +149,7 @@ open class PagerTabStripViewController: UIViewController, UIScrollViewDelegate {
     }
 
     open func moveToViewController(at index: Int, animated: Bool = true) {
-        guard isViewLoaded && view.window != nil && currentIndex != index else {
+        guard isViewLoaded && (view.window != nil || animated == false) && currentIndex != index else {
             preCurrentIndex = index
             return
         }


### PR DESCRIPTION
Skip visibility check (view.window != nil) if non animated viewController change was requested.

User case: a ButtonBarPagerTabStripViewController is not navigationController.topViewController (but was visible so viewDidLoad had been called),
moveToViewController(at: 1, animated: false) was called prior to the screen show (popViewController)
Expected behavior: a controller is shown with selected tab on screen/controller show
Current behavior: a controller change animation starts after the navigation animation is completed.

