### PR TITLE
try to fix issue#741

### DIFF
--- a/Sources/BaseButtonBarPagerTabStripViewController.swift
+++ b/Sources/BaseButtonBarPagerTabStripViewController.swift
@@ -30,6 +30,7 @@ open class BaseButtonBarPagerTabStripViewController<ButtonBarCellType: UICollect
     public var buttonBarItemSpec: ButtonBarItemSpec<ButtonBarCellType>!
     public var changeCurrentIndex: ((_ oldCell: ButtonBarCellType?, _ newCell: ButtonBarCellType?, _ animated: Bool) -> Void)?
     public var changeCurrentIndexProgressive: ((_ oldCell: ButtonBarCellType?, _ newCell: ButtonBarCellType?, _ progressPercentage: CGFloat, _ changeCurrentIndex: Bool, _ animated: Bool) -> Void)?
+    private var oldCurrentIndex: Int = -1
 
     @IBOutlet public weak var buttonBarView: ButtonBarView!
 
@@ -150,6 +151,11 @@ open class BaseButtonBarPagerTabStripViewController<ButtonBarCellType: UICollect
         buttonBarView.moveTo(index: currentIndex, animated: false, swipeDirection: .none, pagerScroll: .yes)
     }
 
+    open override func updateContent() {
+        oldCurrentIndex = currentIndex
+        super.updateContent()
+    }
+
     open func calculateStretchedCellWidths(_ minimumCellWidths: [CGFloat], suggestedStretchedCellWidth: CGFloat, previousNumberOfLargeCells: Int) -> CGFloat {
         var numberOfLargeCells = 0
         var totalWidthOfLargeCells: CGFloat = 0
@@ -205,6 +211,8 @@ open class BaseButtonBarPagerTabStripViewController<ButtonBarCellType: UICollect
     open func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         guard indexPath.item != currentIndex else { return }
 
+        oldCurrentIndex = currentIndex
+
         buttonBarView.moveTo(index: indexPath.item, animated: true, swipeDirection: .none, pagerScroll: .yes)
         shouldUpdateButtonBarView = false
 
@@ -237,13 +245,14 @@ open class BaseButtonBarPagerTabStripViewController<ButtonBarCellType: UICollect
 
         configure(cell: cell, for: indicatorInfo)
 
+        let isCurrentIndex = currentIndex == indexPath.item && oldCurrentIndex != indexPath.item
         if pagerBehaviour.isProgressiveIndicator {
             if let changeCurrentIndexProgressive = changeCurrentIndexProgressive {
-                changeCurrentIndexProgressive(currentIndex == indexPath.item ? nil : cell, currentIndex == indexPath.item ? cell : nil, 1, true, false)
+                changeCurrentIndexProgressive(isCurrentIndex ? nil : cell, isCurrentIndex ? cell : nil, 1, true, false)
             }
         } else {
             if let changeCurrentIndex = changeCurrentIndex {
-                changeCurrentIndex(currentIndex == indexPath.item ? nil : cell, currentIndex == indexPath.item ? cell : nil, false)
+                changeCurrentIndex(isCurrentIndex ? nil : cell, isCurrentIndex ? cell : nil, false)
             }
         }
 

--- a/Sources/ButtonBarPagerTabStripViewController.swift
+++ b/Sources/ButtonBarPagerTabStripViewController.swift
@@ -72,6 +72,8 @@ open class ButtonBarPagerTabStripViewController: PagerTabStripViewController, Pa
 
     public var changeCurrentIndex: ((_ oldCell: ButtonBarViewCell?, _ newCell: ButtonBarViewCell?, _ animated: Bool) -> Void)?
     public var changeCurrentIndexProgressive: ((_ oldCell: ButtonBarViewCell?, _ newCell: ButtonBarViewCell?, _ progressPercentage: CGFloat, _ changeCurrentIndex: Bool, _ animated: Bool) -> Void)?
+    
+    private var oldCurrentIndex: Int = -1
 
     @IBOutlet public weak var buttonBarView: ButtonBarView!
 
@@ -198,6 +200,11 @@ open class ButtonBarPagerTabStripViewController: PagerTabStripViewController, Pa
         cachedCellWidths = calculateWidths()
         buttonBarView.moveTo(index: currentIndex, animated: false, swipeDirection: .none, pagerScroll: .yes)
     }
+    
+    open override func updateContent() {
+        oldCurrentIndex = currentIndex
+        super.updateContent()
+    }
 
     open func calculateStretchedCellWidths(_ minimumCellWidths: [CGFloat], suggestedStretchedCellWidth: CGFloat, previousNumberOfLargeCells: Int) -> CGFloat {
         var numberOfLargeCells = 0
@@ -279,6 +286,8 @@ open class ButtonBarPagerTabStripViewController: PagerTabStripViewController, Pa
     open func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         guard indexPath.item != currentIndex else { return }
 
+        oldCurrentIndex = currentIndex
+
         buttonBarView.moveTo(index: indexPath.item, animated: true, swipeDirection: .none, pagerScroll: .yes)
         shouldUpdateButtonBarView = false
 
@@ -329,13 +338,14 @@ open class ButtonBarPagerTabStripViewController: PagerTabStripViewController, Pa
 
         configureCell(cell, indicatorInfo: indicatorInfo)
 
+        let isCurrentIndex = currentIndex == indexPath.item && oldCurrentIndex != indexPath.item
         if pagerBehaviour.isProgressiveIndicator {
             if let changeCurrentIndexProgressive = changeCurrentIndexProgressive {
-                changeCurrentIndexProgressive(currentIndex == indexPath.item ? nil : cell, currentIndex == indexPath.item ? cell : nil, 1, true, false)
+                changeCurrentIndexProgressive(isCurrentIndex ? nil : cell, isCurrentIndex ? cell : nil, 1, true, false)
             }
         } else {
             if let changeCurrentIndex = changeCurrentIndex {
-                changeCurrentIndex(currentIndex == indexPath.item ? nil : cell, currentIndex == indexPath.item ? cell : nil, false)
+                changeCurrentIndex(isCurrentIndex ? nil : cell, isCurrentIndex ? cell : nil, false)
             }
         }
         cell.isAccessibilityElement = true


### PR DESCRIPTION
Sorry for the ugly English.

I tried to fix the issue #741 .
This issue can happen frequently, so consider merging.

### Cause
There are two cause for this issue:

1. In changeCurrentIndexProgressive in didSelectItemAt, OldCell is nil, because OldCell is off the screen.

2. cellForItemAt is called when an OldCell outside the screen enters the screen with moveTo.
However, the currentIndex has not been updated, the OldCell is determined to be a NewCell.

### Amendment policy
The fix was applied only inside the buttonBar related sources. Because of the following two reasons

1. We also considered modifying PagerTabStripViewController, but the scope of influence is too wide.

2. changeCurrentIndexProgressive exists only in buttonBar.