### PR TITLE
Fix bug with vertical scroll position

### DIFF
--- a/Sources/PagerTabStripViewController.swift
+++ b/Sources/PagerTabStripViewController.swift
@@ -154,6 +154,13 @@ open class PagerTabStripViewController: UIViewController, UIScrollViewDelegate {
             return
         }
 
+        let top: CGFloat
+        if #available(iOS 11.0, *) {
+            top = -containerView.adjustedContentInset.top
+        } else {
+            top = 0
+        }
+        
         if animated && pagerBehaviour.skipIntermediateViewControllers && abs(currentIndex - index) > 1 {
             var tmpViewControllers = viewControllers
             let currentChildVC = viewControllers[currentIndex]
@@ -162,12 +169,12 @@ open class PagerTabStripViewController: UIViewController, UIScrollViewDelegate {
             tmpViewControllers[currentIndex] = fromChildVC
             tmpViewControllers[fromIndex] = currentChildVC
             pagerTabStripChildViewControllersForScrolling = tmpViewControllers
-            containerView.setContentOffset(CGPoint(x: pageOffsetForChild(at: fromIndex), y: 0), animated: false)
+            containerView.setContentOffset(CGPoint(x: pageOffsetForChild(at: fromIndex), y: top), animated: false)
             (navigationController?.view ?? view).isUserInteractionEnabled = !animated
-            containerView.setContentOffset(CGPoint(x: pageOffsetForChild(at: index), y: 0), animated: true)
+            containerView.setContentOffset(CGPoint(x: pageOffsetForChild(at: index), y: top), animated: true)
         } else {
             (navigationController?.view ?? view).isUserInteractionEnabled = !animated
-            containerView.setContentOffset(CGPoint(x: pageOffsetForChild(at: index), y: 0), animated: animated)
+            containerView.setContentOffset(CGPoint(x: pageOffsetForChild(at: index), y: top), animated: animated)
         }
     }
 

--- a/Sources/PagerTabStripViewController.swift
+++ b/Sources/PagerTabStripViewController.swift
@@ -158,7 +158,7 @@ open class PagerTabStripViewController: UIViewController, UIScrollViewDelegate {
         if #available(iOS 11.0, *) {
             top = -containerView.adjustedContentInset.top
         } else {
-            top = 0
+            top = -containerView.contentInset.top
         }
         
         if animated && pagerBehaviour.skipIntermediateViewControllers && abs(currentIndex - index) > 1 {


### PR DESCRIPTION
When using the tab strip buttons to scroll between different ViewControllers, PagerTabStripViewController would not respect content inset of child view controller and scroll above it.  (ie: when additionalSafeAreaInsets are != 0 then top is != 0)