### PR TITLE
Addind SwiftPM support

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,31 @@
+// swift-tools-version:5.3
+
+import PackageDescription
+
+let package = Package(
+    name: "XLPagerTabStrip",
+    platforms: [
+        .iOS(.v9)
+    ],
+    products: [
+        .library(
+            name: "XLPagerTabStrip",
+            targets: ["XLPagerTabStrip"]
+        )
+    ],
+    targets: [
+        .target(
+            name: "XLPagerTabStrip",
+            path: "Sources",
+            exclude: [
+                "FXPageControl.h",
+                "FXPageControl.m"
+            ]
+        ),
+        .testTarget(
+            name: "XLPagerTabStripTests",
+            dependencies: ["XLPagerTabStrip"],
+            path: "Tests"
+        )
+    ]
+)


### PR DESCRIPTION
I added a SPM package manifest, to allow others that are not using Cocoapods to use this project anyways.

I haven't added any package dependencies, since I couldn't spot any non standard imports in the code.
Also the `FXPageControl` files are excluded, because they are ObjC and as far as I know packages mustn't be multi language.