### PR TITLE
Optimize for more efficient and predictable performance by changing Array to CountiguousArray

### DIFF
--- a/Example/Example/BarExampleViewController.swift
+++ b/Example/Example/BarExampleViewController.swift
@@ -43,7 +43,7 @@ class BarExampleViewController: BarPagerTabStripViewController {
 
     // MARK: - PagerTabStripDataSource
 
-    override func viewControllers(for pagerTabStripController: PagerTabStripViewController) -> [UIViewController] {
+    override func viewControllers(for pagerTabStripController: PagerTabStripViewController) -> ContiguousArray<UIViewController> {
 
         let child_1 = TableChildExampleViewController(style: .plain, itemInfo: "Table View")
         let child_2 = ChildExampleViewController(itemInfo: "View")
@@ -63,7 +63,7 @@ class BarExampleViewController: BarPagerTabStripViewController {
             }
         }
         let nItems = 1 + (arc4random() % 4)
-        return Array(childViewControllers.prefix(Int(nItems)))
+        return ContiguousArray(childViewControllers.prefix(Int(nItems)))
     }
 
     override func reloadPagerTabStripView() {

--- a/Example/Example/ButtonBarExampleViewController.swift
+++ b/Example/Example/ButtonBarExampleViewController.swift
@@ -38,7 +38,7 @@ class ButtonBarExampleViewController: ButtonBarPagerTabStripViewController {
 
     // MARK: - PagerTabStripDataSource
 
-    override func viewControllers(for pagerTabStripController: PagerTabStripViewController) -> [UIViewController] {
+    override func viewControllers(for pagerTabStripController: PagerTabStripViewController) -> ContiguousArray<UIViewController> {
         let child_1 = TableChildExampleViewController(style: .plain, itemInfo: "Table View")
         let child_2 = ChildExampleViewController(itemInfo: "View")
         let child_3 = TableChildExampleViewController(style: .grouped, itemInfo: "Table View 2")
@@ -62,7 +62,7 @@ class ButtonBarExampleViewController: ButtonBarPagerTabStripViewController {
             }
         }
         let nItems = 1 + (arc4random() % 8)
-        return Array(childViewControllers.prefix(Int(nItems)))
+        return ContiguousArray(childViewControllers.prefix(Int(nItems)))
     }
 
     override func reloadPagerTabStripView() {

--- a/Example/Example/Instagram/InstagramExampleViewController.swift
+++ b/Example/Example/Instagram/InstagramExampleViewController.swift
@@ -53,7 +53,7 @@ class InstagramExampleViewController: ButtonBarPagerTabStripViewController {
 
     // MARK: - PagerTabStripDataSource
 
-    override func viewControllers(for pagerTabStripController: PagerTabStripViewController) -> [UIViewController] {
+    override func viewControllers(for pagerTabStripController: PagerTabStripViewController) -> ContiguousArray<UIViewController> {
         let child_1 = TableChildExampleViewController(style: .plain, itemInfo: "FOLLOWING")
         let child_2 = ChildExampleViewController(itemInfo: "YOU")
         return [child_1, child_2]

--- a/Example/Example/NavButtonBarExampleViewController.swift
+++ b/Example/Example/NavButtonBarExampleViewController.swift
@@ -58,7 +58,7 @@ class NavButtonBarExampleViewController: ButtonBarPagerTabStripViewController {
 
     // MARK: - PagerTabStripDataSource
 
-    override func viewControllers(for pagerTabStripController: PagerTabStripViewController) -> [UIViewController] {
+    override func viewControllers(for pagerTabStripController: PagerTabStripViewController) -> ContiguousArray<UIViewController> {
         let child_1 = TableChildExampleViewController(style: .plain, itemInfo: "Table View")
         let child_2 = ChildExampleViewController(itemInfo: "View")
         let child_3 = TableChildExampleViewController(style: .grouped, itemInfo: "Table View 2")
@@ -82,7 +82,7 @@ class NavButtonBarExampleViewController: ButtonBarPagerTabStripViewController {
             }
         }
         let nItems = 1 + (arc4random() % 8)
-        return Array(childViewControllers.prefix(Int(nItems)))
+        return ContiguousArray(childViewControllers.prefix(Int(nItems)))
     }
 
     override func reloadPagerTabStripView() {

--- a/Example/Example/SegmentedExampleViewController.swift
+++ b/Example/Example/SegmentedExampleViewController.swift
@@ -37,7 +37,7 @@ class SegmentedExampleViewController: SegmentedPagerTabStripViewController {
 
     // MARK: - PagerTabStripDataSource
 
-    override func viewControllers(for pagerTabStripController: PagerTabStripViewController) -> [UIViewController] {
+    override func viewControllers(for pagerTabStripController: PagerTabStripViewController) -> ContiguousArray<UIViewController> {
         let child_1 = TableChildExampleViewController(style: .plain, itemInfo: "Table View")
         let child_2 = ChildExampleViewController(itemInfo: "View")
         let child_3 = TableChildExampleViewController(style: .grouped, itemInfo: "Table View 2")
@@ -58,7 +58,7 @@ class SegmentedExampleViewController: SegmentedPagerTabStripViewController {
             }
         }
         let nItems = 1 + (arc4random() % 4)
-        return Array(childViewControllers.prefix(Int(nItems)))
+        return ContiguousArray(childViewControllers.prefix(Int(nItems)))
     }
 
     @IBAction func reloadTapped(_ sender: UIBarButtonItem) {

--- a/Example/Example/Spotify/SpotifyExampleViewController.swift
+++ b/Example/Example/Spotify/SpotifyExampleViewController.swift
@@ -56,7 +56,7 @@ class SpotifyExampleViewController: ButtonBarPagerTabStripViewController {
 
     // MARK: - PagerTabStripDataSource
 
-    override func viewControllers(for pagerTabStripController: PagerTabStripViewController) -> [UIViewController] {
+    override func viewControllers(for pagerTabStripController: PagerTabStripViewController) -> ContiguousArray<UIViewController> {
         let child_1 = TableChildExampleViewController(style: .plain, itemInfo: IndicatorInfo(title: "FRIENDS"))
         child_1.blackTheme = true
         let child_2 = TableChildExampleViewController(style: .plain, itemInfo: IndicatorInfo(title: "FEATURED"))

--- a/Example/Example/TwitterExampleViewController.swift
+++ b/Example/Example/TwitterExampleViewController.swift
@@ -28,7 +28,7 @@ import XLPagerTabStrip
 class TwitterExampleViewController: TwitterPagerTabStripViewController {
     var isReload = false
 
-    override func viewControllers(for pagerTabStripController: PagerTabStripViewController) -> [UIViewController] {
+    override func viewControllers(for pagerTabStripController: PagerTabStripViewController) -> ContiguousArray<UIViewController> {
 
         let child_1 = TableChildExampleViewController(style: .plain, itemInfo: "TableView")
         let child_2 = ChildExampleViewController(itemInfo: "View")
@@ -53,7 +53,7 @@ class TwitterExampleViewController: TwitterPagerTabStripViewController {
             }
         }
         let nItems = 1 + (arc4random() % 8)
-        return Array(childViewControllers.prefix(Int(nItems)))
+        return ContiguousArray(childViewControllers.prefix(Int(nItems)))
     }
 
     @IBAction func reloadTapped(_ sender: AnyObject) {

--- a/Example/Example/Youtube/YoutubeExampleViewController.swift
+++ b/Example/Example/Youtube/YoutubeExampleViewController.swift
@@ -66,7 +66,7 @@ class YoutubeExampleViewController: BaseButtonBarPagerTabStripViewController<You
 
     // MARK: - PagerTabStripDataSource
 
-    override func viewControllers(for pagerTabStripController: PagerTabStripViewController) -> [UIViewController] {
+    override func viewControllers(for pagerTabStripController: PagerTabStripViewController) -> ContiguousArray<UIViewController> {
         let child_1 = TableChildExampleViewController(style: .plain, itemInfo: IndicatorInfo(title: " HOME", image: UIImage(named: "home")))
         let child_2 = TableChildExampleViewController(style: .plain, itemInfo: IndicatorInfo(title: " TRENDING", image: UIImage(named: "trending")))
         let child_3 = ChildExampleViewController(itemInfo: IndicatorInfo(title: " ACCOUNT", image: UIImage(named: "profile")))

--- a/Example/Example/YoutubeWithLabel/YoutubeWithLabelExampleViewController.swift
+++ b/Example/Example/YoutubeWithLabel/YoutubeWithLabelExampleViewController.swift
@@ -68,7 +68,7 @@ class YoutubeWithLabelExampleViewController: BaseButtonBarPagerTabStripViewContr
 
     // MARK: - PagerTabStripDataSource
 
-    override func viewControllers(for pagerTabStripController: PagerTabStripViewController) -> [UIViewController] {
+    override func viewControllers(for pagerTabStripController: PagerTabStripViewController) -> ContiguousArray<UIViewController> {
         let child_1 = TableChildExampleViewController(style: .plain, itemInfo: IndicatorInfo(title: " HOME", image: UIImage(named: "home")))
         let child_2 = TableChildExampleViewController(style: .plain, itemInfo: IndicatorInfo(title: " TRENDING", image: UIImage(named: "trending")))
         let child_3 = ChildExampleViewController(itemInfo: IndicatorInfo(title: " ACCOUNT", image: UIImage(named: "profile")))

--- a/Sources/PagerTabStripViewController.swift
+++ b/Sources/PagerTabStripViewController.swift
@@ -44,7 +44,7 @@ public protocol PagerTabStripIsProgressiveDelegate: PagerTabStripDelegate {
 
 public protocol PagerTabStripDataSource: class {
 
-    func viewControllers(for pagerTabStripController: PagerTabStripViewController) -> [UIViewController]
+    func viewControllers(for pagerTabStripController: PagerTabStripViewController) -> ContiguousArray<UIViewController>
 }
 
 // MARK: PagerTabStripViewController
@@ -58,7 +58,7 @@ open class PagerTabStripViewController: UIViewController, UIScrollViewDelegate {
 
     open var pagerBehaviour = PagerTabStripBehaviour.progressive(skipIntermediateViewControllers: true, elasticIndicatorLimit: true)
 
-    open private(set) var viewControllers = [UIViewController]()
+    open private(set) var viewControllers = ContiguousArray<UIViewController>()
     open private(set) var currentIndex = 0
     open private(set) var preCurrentIndex = 0 // used *only* to store the index to which move when the pager becomes visible
 
@@ -177,7 +177,7 @@ open class PagerTabStripViewController: UIViewController, UIScrollViewDelegate {
 
     // MARK: - PagerTabStripDataSource
 
-    open func viewControllers(for pagerTabStripController: PagerTabStripViewController) -> [UIViewController] {
+    open func viewControllers(for pagerTabStripController: PagerTabStripViewController) -> ContiguousArray<UIViewController> {
         assertionFailure("Sub-class must implement the PagerTabStripDataSource viewControllers(for:) method")
         return []
     }
@@ -385,7 +385,7 @@ open class PagerTabStripViewController: UIViewController, UIScrollViewDelegate {
 
     }
 
-    private var pagerTabStripChildViewControllersForScrolling: [UIViewController]?
+    private var pagerTabStripChildViewControllersForScrolling: ContiguousArray<UIViewController>?
     private var lastPageNumber = 0
     private var lastContentOffset: CGFloat = 0.0
     private var pageBeforeRotate = 0

--- a/XLPagerTabStrip.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/XLPagerTabStrip.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
I changed to use ContiguousArray< UIViewController > type to store UIViewControllers in a contiguous block of memory.

 When using a large number of UIViewControllers as tabs, I think that using ContiguousArray will yield more predictable performance compared to Array.


The changed source file is:
- Sources/PagerTabStripViewController.swift

for Example:
- BarExampleViewController.swift
- ButtonBarExampleViewController.swift
- InstagramExampleViewController.swift
- NavButtonBarExampleViewController.swift
- SegmentedExampleViewController.swift
- SpotifyExampleViewController.swift
- TwitterExampleViewController.swift
- YoutubeExampleViewController.swift
- YoutubeWithLabelExampleViewController.swift


References
- https://github.com/apple/swift/blob/main/docs/Arrays.rst
- https://developer.apple.com/documentation/swift/contiguousarray
- https://github.com/apple/swift/blob/main/docs/OptimizationTips.rst#advice-use-contiguousarray-with-reference-types-when-nsarray-bridging-is-unnecessary
- http://jordansmith.io/on-performant-arrays-in-swift/
- https://medium.com/@nitingeorge_39047/swift-array-vs-contiguousarray-a6153098a5