### PR TITLE
Fix safe area bug after iOS 11.0

### DIFF
--- a/Sources/PagerTabStripViewController.swift
+++ b/Sources/PagerTabStripViewController.swift
@@ -240,39 +240,22 @@ open class PagerTabStripViewController: UIViewController, UIScrollViewDelegate {
 
         for (index, childController) in pagerViewControllers.enumerated() {
             let pageOffsetForChild = self.pageOffsetForChild(at: index)
+            
             if abs(containerView.contentOffset.x - pageOffsetForChild) < containerView.bounds.width {
-                
-                if let _ = childController.parent {
                 if #available(iOS 11.0, *) {
-                childController.view.frame = CGRect(x: offsetForChild(at: index) + view.safeAreaInsets.left, y: 0, width: view.bounds.width - (view.safeAreaInsets.left + view.safeAreaInsets.right), height: containerView.bounds.height)
+                    if case 0 = index {
+                        childController.view.frame = CGRect(x: offsetForChild(at: index), y: 0, width: view.bounds.width - view.safeAreaInsets.right, height: containerView.bounds.height)
+                    } else {
+                        childController.view.frame = CGRect(x: offsetForChild(at: index) + view.safeAreaInsets.left, y: 0, width: view.bounds.width - view.safeAreaInsets.right, height: containerView.bounds.height)
+                    }
                 } else {
-                childController.view.frame = CGRect(x: offsetForChild(at: index), y: 0, width: view.bounds.width, height: containerView.bounds.height)
-                }
-                childController.view.autoresizingMask = [.flexibleHeight, .flexibleWidth]
-                }
-                else {
-                childController.beginAppearanceTransition(true, animated: false)
-                    addChild(childController)
-                if #available(iOS 11.0, *) {
-                childController.view.frame = CGRect(x: offsetForChild(at: index) + view.safeAreaInsets.left, y: 0, width: view.bounds.width - (view.safeAreaInsets.left + view.safeAreaInsets.right), height: containerView.bounds.height)
-                } else {
-                childController.view.frame = CGRect(x: offsetForChild(at: index), y: 0, width: view.bounds.width, height: containerView.bounds.height)
-                }
-                childController.view.autoresizingMask = [.flexibleHeight, .flexibleWidth]
-                containerView.addSubview(childController.view)
-                    childController.didMove(toParent: self)
-                childController.endAppearanceTransition()
-                }
-                
-                
-                if childController.parent != nil {
                     childController.view.frame = CGRect(x: offsetForChild(at: index), y: 0, width: view.bounds.width, height: containerView.bounds.height)
-                    childController.view.autoresizingMask = [.flexibleHeight, .flexibleWidth]
-                } else {
+                }
+                childController.view.autoresizingMask = [.flexibleHeight, .flexibleWidth]
+                
+                if childController.parent == nil {
                     childController.beginAppearanceTransition(true, animated: false)
                     addChild(childController)
-                    childController.view.frame = CGRect(x: offsetForChild(at: index), y: 0, width: view.bounds.width, height: containerView.bounds.height)
-                    childController.view.autoresizingMask = [.flexibleHeight, .flexibleWidth]
                     containerView.addSubview(childController.view)
                     childController.didMove(toParent: self)
                     childController.endAppearanceTransition()

--- a/Sources/PagerTabStripViewController.swift
+++ b/Sources/PagerTabStripViewController.swift
@@ -241,6 +241,30 @@ open class PagerTabStripViewController: UIViewController, UIScrollViewDelegate {
         for (index, childController) in pagerViewControllers.enumerated() {
             let pageOffsetForChild = self.pageOffsetForChild(at: index)
             if abs(containerView.contentOffset.x - pageOffsetForChild) < containerView.bounds.width {
+                
+                if let _ = childController.parent {
+                if #available(iOS 11.0, *) {
+                childController.view.frame = CGRect(x: offsetForChild(at: index) + view.safeAreaInsets.left, y: 0, width: view.bounds.width - (view.safeAreaInsets.left + view.safeAreaInsets.right), height: containerView.bounds.height)
+                } else {
+                childController.view.frame = CGRect(x: offsetForChild(at: index), y: 0, width: view.bounds.width, height: containerView.bounds.height)
+                }
+                childController.view.autoresizingMask = [.flexibleHeight, .flexibleWidth]
+                }
+                else {
+                childController.beginAppearanceTransition(true, animated: false)
+                    addChild(childController)
+                if #available(iOS 11.0, *) {
+                childController.view.frame = CGRect(x: offsetForChild(at: index) + view.safeAreaInsets.left, y: 0, width: view.bounds.width - (view.safeAreaInsets.left + view.safeAreaInsets.right), height: containerView.bounds.height)
+                } else {
+                childController.view.frame = CGRect(x: offsetForChild(at: index), y: 0, width: view.bounds.width, height: containerView.bounds.height)
+                }
+                childController.view.autoresizingMask = [.flexibleHeight, .flexibleWidth]
+                containerView.addSubview(childController.view)
+                    childController.didMove(toParent: self)
+                childController.endAppearanceTransition()
+                }
+                
+                
                 if childController.parent != nil {
                     childController.view.frame = CGRect(x: offsetForChild(at: index), y: 0, width: view.bounds.width, height: containerView.bounds.height)
                     childController.view.autoresizingMask = [.flexibleHeight, .flexibleWidth]


### PR DESCRIPTION
Fix the problem that the frame of the child view is not properly set because safe area is not considered in iOS 11 and later versions.