### PR TITLE
Make it possible for Obj-C view controller to implement IndicatorInfoProvider protocol

### DIFF
--- a/Sources/IndicatorInfo.swift
+++ b/Sources/IndicatorInfo.swift
@@ -24,17 +24,15 @@
 
 import Foundation
 
-public struct IndicatorInfo {
+@objcMembers public class IndicatorInfo: NSObject {
 
     public var title: String?
     public var image: UIImage?
     public var highlightedImage: UIImage?
-    public var accessibilityLabel: String?
     public var userInfo: Any?
     
     public init(title: String?) {
         self.title = title
-        self.accessibilityLabel = title
     }
     
     public init(image: UIImage?, highlightedImage: UIImage? = nil, userInfo: Any? = nil) {
@@ -45,7 +43,6 @@ public struct IndicatorInfo {
     
     public init(title: String?, image: UIImage?, highlightedImage: UIImage? = nil, userInfo: Any? = nil) {
         self.title = title
-        self.accessibilityLabel = title
         self.image = image
         self.highlightedImage = highlightedImage
         self.userInfo = userInfo
@@ -53,7 +50,6 @@ public struct IndicatorInfo {
     
     public init(title: String?, accessibilityLabel:String?, image: UIImage?, highlightedImage: UIImage? = nil, userInfo: Any? = nil) {
         self.title = title
-        self.accessibilityLabel = accessibilityLabel
         self.image = image
         self.highlightedImage = highlightedImage
         self.userInfo = userInfo
@@ -61,20 +57,21 @@ public struct IndicatorInfo {
 
 }
 
-extension IndicatorInfo : ExpressibleByStringLiteral {
+//extension IndicatorInfo : ExpressibleByStringLiteral {
+//
+//    public init(stringLiteral value: String) {
+//        title = value
+//        accessibilityLabel = value
+//    }
+//
+//    public init(extendedGraphemeClusterLiteral value: String) {
+//        title = value
+//        accessibilityLabel = value
+//    }
+//
+//    public init(unicodeScalarLiteral value: String) {
+//        title = value
+//        accessibilityLabel = value
+//    }
+//}
 
-    public init(stringLiteral value: String) {
-        title = value
-        accessibilityLabel = value
-    }
-
-    public init(extendedGraphemeClusterLiteral value: String) {
-        title = value
-        accessibilityLabel = value
-    }
-
-    public init(unicodeScalarLiteral value: String) {
-        title = value
-        accessibilityLabel = value
-    }
-}

--- a/Sources/PagerTabStripViewController.swift
+++ b/Sources/PagerTabStripViewController.swift
@@ -26,7 +26,7 @@ import Foundation
 
 // MARK: Protocols
 
-public protocol IndicatorInfoProvider {
+@objc public protocol IndicatorInfoProvider {
 
     func indicatorInfo(for pagerTabStripController: PagerTabStripViewController) -> IndicatorInfo
 


### PR DESCRIPTION
In order to display a View Controller (VC) as a child of a Pager controller, the child VC needs to conform to the `IndicatorInfoProvider` protocol in order to let the pager know what to use as the VC's title in the pager.

However, if a VC is written in Obj-C, it is currently impossible to have it as a child of a pager because the `IndicatorInfoProvider` protocol isn't made available to Obj-C. In order to make it available, the following minor changes have been made:

- Added the `@objc` flag to the protocol
- Structs don't exist in Obj-C, but the protocol function returns a struct. Refactored its return type to be a Class instead of a Struct.
