### PR TITLE
[feat] add padding to the bottom of the selectedBar

### DIFF
--- a/Sources/ButtonBarView.swift
+++ b/Sources/ButtonBarView.swift
@@ -41,6 +41,7 @@ public enum SelectedBarVerticalAlignment {
     case top
     case middle
     case bottom
+    case customBottom(spaceFromBottom: CGFloat)
 }
 
 open class ButtonBarView: UICollectionView {
@@ -178,6 +179,8 @@ open class ButtonBarView: UICollectionView {
             selectedBarFrame.origin.y = (frame.size.height - selectedBarHeight) / 2
         case .bottom:
             selectedBarFrame.origin.y = frame.size.height - selectedBarHeight
+        case .customBottom(let spaceFromBottom):
+            selectedBarFrame.origin.y = frame.size.height - selectedBarHeight - spaceFromBottom
         }
 
         selectedBarFrame.size.height = selectedBarHeight


### PR DESCRIPTION
### add padding to the bottom of the selectedBar

Thanks for everything !

Close #.

I added new custom property. `.customBottom(spaceFromBottom: CGFloat)`

It can shift the position of the selectedBar upward by `spaceFromBottom` pt.

<table>
  <thead>
    <tr>
      <td>Before</td>
      <td>After</td>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><video src="https://user-images.githubusercontent.com/52638834/213920945-b36551ba-f2b7-4d0f-8a31-be4f3a47cd2b.mov"/></td>
      <td><video src="https://user-images.githubusercontent.com/52638834/213920933-cfecbf90-7a45-440c-a691-867d4abc5160.mov"/></td>
    </tr>
  </tbody>
</table>

Looking forward to a good reply.
Thanks!